### PR TITLE
Bump ds4 submodule to upstream 84cc882 (118 commits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## Unreleased
+- ds4 submodule bumped 54b36ed → upstream `84cc882` (118 commits), with our THINK_MAX patch rebased on top (`ds4-control-patches-v2`). Highlights:
+  - **Correctness, and it applied to us.** `metal: fix long-context prefill and decode correctness` fixes a missing device-memory barrier in the RoPE helper (`mem_threadgroup` → `mem_device_and_threadgroup`; it writes device memory other lanes read, so a threadgroup-only fence left a race), and disables a non-reproducible streaming top-k selector whose trigger — `top_k == 512 && n_comp > 1024 && n_tokens >= 32` — is exactly V4 Flash's `index_topk: 512` on long-context prefill.
+  - **Decode is measurably faster on Apple Silicon.** Upstream's "exact" fusion campaign (bit-identical A/B verified across 134.6M F32 logits) reports M3 Ultra 41.08 → 44.18 tok/s. Measured here on q4-imatrix with an identical 400-token greedy prompt: **34.85 → 40.07 tok/s (+15%)**.
+  - **MXFP4 routed experts are now supported** (`DS4_TENSOR_MXFP4` in `tensor_is_routed_expert_type`, 179 mentions in `metal/moe.metal`), so upstream's `ds4f-mxfp4` build (~156 GB) becomes runnable. Not yet offered in the app.
+  - Prefill acceleration (routed MoE, indexed, Metal 4 Q4 attention output, Q-head norm + RoPE fusion), streamed-expert mlock pinning restored, and ~8 DSpark commits including `Restore greedy identity after DSpark acceptance` and `Make DSpark scheduling deterministic by default`.
+  - `download_model.sh` gains the renamed `ds4f-*` targets (`ds4f-q2`, `ds4f-q2-q4`, `ds4f-q4`, `ds4f-mxfp4`, `ds4f-dspark`). These resolve to the *same* `-0731` files the app already downloads natively, so nothing in the app changes.
+  - Note: ds4's default DSpark confidence threshold moved from 0.9 to Metal 0.6 / CUDA-ROCm 0.7.
 
 ## v1.1.0 — 2026-08-03
 - Fix: after an unexpected ds4-server exit (typically a bind conflict with an orphaned server that owns the port), adopt the healthy port-holder as ready instead of dead-ending in an error whose Retry could only fail the same way again.


### PR DESCRIPTION
Moves `external/ds4` from `54b36ed` to upstream `antirez/ds4` main, with our single THINK_MAX patch rebased on top as `ds4-control-patches-v2` (pushed to the fork, so the submodule pointer resolves for CI and fresh clones).

## Why now: correctness, not speed

`metal: fix long-context prefill and decode correctness` fixes two real bugs, both of which applied to us:

- **A missing device-memory barrier in the RoPE helper** — `mem_threadgroup` → `mem_device_and_threadgroup`. It writes device memory that other lanes then read, so a threadgroup-only fence left a genuine race producing nondeterministically wrong output. Unconditional.
- **A non-reproducible streaming top-k selector**, now off unless `DS4_METAL_ENABLE_STREAMING_TOPK512` is set. Its trigger is `top_k == 512 && n_comp > 1024 && n_tokens >= 32` — and V4 Flash's config sets `index_topk: 512`, so this was our exact configuration on long-context prefill.

## Measured speedup

Upstream's "exact" fusion campaign is bit-identical (verified A/B over 134,580,480 F32 logits) and reports M3 Ultra 41.08 → 44.18 tok/s.

Measured on this machine, q4-imatrix, identical 400-token greedy prompt at `--ctx 32768`:

| | mean | samples |
|---|---|---|
| before | 34.85 tok/s | 34.75, 34.87, 34.44, 35.34 |
| after | **40.07 tok/s** | 39.07 (cold), 40.40, 40.47, 40.35 |

**+15%.**

## Also unlocked

- **MXFP4 routed experts** — `DS4_TENSOR_MXFP4` is now in `tensor_is_routed_expert_type`, with 179 mentions in `metal/moe.metal`. Upstream's `ds4f-mxfp4` build (~156 GB) is runnable. Not offered in the app yet; worth evaluating, since if MXFP4 is the native format of the released FP4 experts it would reach the fidelity ceiling at roughly half the size of the q8 build.
- Prefill acceleration (routed MoE, indexed, Metal 4 Q4 attention output, Q-head norm + RoPE fusion), streamed-expert mlock pinning restored.
- ~8 DSpark commits, including `Restore greedy identity after DSpark acceptance` and `Make DSpark scheduling deterministic by default` — relevant to #9.

## Notes

- `download_model.sh` gains the renamed `ds4f-*` targets. They resolve to the **same** `-0731` filenames the app already downloads natively, so no app change is required.
- ds4's default DSpark confidence threshold moved 0.9 → Metal 0.6 / CUDA-ROCm 0.7.
- Our THINK_MAX patch is still needed: upstream still ships the "Absolute maximum" text at that constant. Verified in the built binary — `Beyond maximum` ×1, `Absolute maximum` ×0.

## Verification

- Cherry-pick applied with no conflict; patch verified semantically against the moved code.
- `make` clean; `ds4-server` and `download_model.sh` present and executable (what `validateDs4Dir` requires).
- `swift test`: 161 passed, 0 failures (main's baseline).
- Server loads q4-imatrix on Metal and generates correctly.

⚠️ This touches the signed/notarized release path — worth a release-build smoke test before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved decoding support and accuracy on Apple Silicon devices.
  - Added support for MXFP4 routed-expert workloads.
  - Updated prefill processing and memory handling for smoother execution.
  - Refined DSpark confidence behavior for more reliable results.

- **Maintenance**
  - Updated download targets and refreshed the underlying inference components.
  - Included correctness fixes across supported workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->