### PR TITLE
feat: SSD streaming for ds4-server (default on, ~15 GiB freed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It launches, supervises, and monitors a local ds4 server, lets you pick **V4 Pro
 
 - **Start / stop / monitor** the local `ds4-server` child process — spawn, stderr readiness detection, health polling, graceful stop, and crash detection.
 - **Pro / Flash selector** with a RAM feasibility gate.
+- **SSD streaming** (on by default): keeps ~15 GiB less of the model resident by caching only part of the routed experts; budget adjustable in Settings.
 - **Model downloads** via a built-in native parallel downloader, with a live progress bar and resume across restarts.
 - **Mini resource widgets**: unified memory, GPU, power, and CPU, sampled on a timer.
 - **Launch Chat** to talk to the model.

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -16,6 +16,13 @@ final class AppState: ObservableObject {
     /// keeping the original single-session path. Memory grows with sessions × context.
     @Published var concurrentSessions: Int { didSet { d.set(concurrentSessions, forKey: "concurrentSessions") } }
     @Published var kvDiskCache: Bool { didSet { d.set(kvDiskCache, forKey: "kvDiskCache") } }
+    /// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM; the
+    /// rest stream from the GGUF on demand. Default ON with the ~15 GiB-free budget
+    /// for the selected quant.
+    @Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+    @Published var ssdStreamingCacheGB: Int {
+        didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+    }
     /// The chat's thinking level (Off / Standard / Max Think). Coding-agent CLIs set their
     /// own per-request level, so this affects only the built-in chat.
     @Published var thinkingMode: ThinkingMode { didSet { d.set(thinkingMode.rawValue, forKey: "thinkingMode") } }
@@ -83,7 +90,14 @@ final class AppState: ObservableObject {
         let stored = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:))
         selectedVariant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
         let storedQuant = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
-        selectedFlashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
+        let flashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
+        selectedFlashQuant = flashQuant
+        ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true  // default on
+        if let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int {
+            ssdStreamingCacheGB = storedGB
+        } else {
+            ssdStreamingCacheGB = Quant.for(selectedVariant, flashQuant: flashQuant).defaultStreamingCacheGB
+        }
     }
 
     func effectiveCtx(ramGiB: Double) -> Int {

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -88,7 +88,8 @@ final class AppState: ObservableObject {
         launchAtLogin = SMAppService.mainApp.status == .enabled  // OS is the source of truth
         legacyWeightsPromptDismissed = d.bool(forKey: "legacyWeightsPromptDismissed0731")  // default false
         let stored = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:))
-        selectedVariant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
+        let variant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
+        selectedVariant = variant
         let storedQuant = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
         let flashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
         selectedFlashQuant = flashQuant
@@ -96,7 +97,7 @@ final class AppState: ObservableObject {
         if let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int {
             ssdStreamingCacheGB = storedGB
         } else {
-            ssdStreamingCacheGB = Quant.for(selectedVariant, flashQuant: flashQuant).defaultStreamingCacheGB
+            ssdStreamingCacheGB = Quant.for(variant, flashQuant: flashQuant).defaultStreamingCacheGB
         }
     }
 

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -362,10 +362,23 @@ private func metalIndexerScratchBytes(variant: Variant, ctx: Int) -> Int? {
 /// one prefill workspace plus persistent backend scratch shared across sessions. Context
 /// counts regardless of the disk KV cache: disk storage checkpoints resident tensors; it
 /// does not replace them.
-func requiredWiredMB(variant: Variant, flashQuant: FlashQuant, ctx: Int, sessions: Int = 1) -> Int {
+func requiredWiredMB(
+    variant: Variant, flashQuant: FlashQuant, ctx: Int, sessions: Int = 1,
+    ssdStreamingCacheGB: Int = 0
+) -> Int {
     let quant = Quant.for(variant, flashQuant: flashQuant)
+    // SSD streaming keeps only the expert-cache budget + non-routed weights resident;
+    // the routed experts beyond the budget stream from the GGUF on demand. Charge the
+    // resident set (not the full GGUF) when a budget is in effect.
+    let residentWeightsMB: Int?
+    if ssdStreamingCacheGB > 0 {
+        let residentGiB = quant.weightsGiB - quant.routedExpertGiB + Double(ssdStreamingCacheGB)
+        residentWeightsMB = roundedUpMiB(Int(residentGiB * 1_073_741_824))
+    } else {
+        residentWeightsMB = roundedUpMiB(quant.ggufBytes)
+    }
     guard
-        let weightsMB = roundedUpMiB(quant.ggufBytes),
+        let weightsMB = residentWeightsMB,
         let sessionBytes = metalContextBytes(variant: variant, ctx: ctx),
         let sessionGraphBytes = metalSessionGraphBytes(variant: variant, ctx: ctx),
         let sharedGraphBytes = metalSharedGraphWorkspaceBytes(variant: variant, ctx: ctx),
@@ -424,7 +437,7 @@ func defaultFlashQuant(ramGiB: Double) -> FlashQuant {
 /// ceiling (`wiredLimitMB` — inject `effectiveWiredLimitMB(ramGiB:)` at the call site).
 func feasibility(
     ramGiB: Double, variant: Variant, flashQuant: FlashQuant,
-    ctx: Int, wiredLimitMB: Int, sessions: Int = 1
+    ctx: Int, wiredLimitMB: Int, sessions: Int = 1, ssdStreamingCacheGB: Int = 0
 ) -> Feasibility {
     if let reason = launchBoundsError(variant: variant, ctx: ctx, sessions: sessions) {
         return .blocked(reason: reason)
@@ -441,7 +454,8 @@ func feasibility(
         }
     }
     let required = requiredWiredMB(
-        variant: variant, flashQuant: flashQuant, ctx: ctx, sessions: sessions)
+        variant: variant, flashQuant: flashQuant, ctx: ctx, sessions: sessions,
+        ssdStreamingCacheGB: ssdStreamingCacheGB)
     if required == Int.max {
         return .blocked(
             reason:

--- a/Sources/DS4Control/Model/Variant.swift
+++ b/Sources/DS4Control/Model/Variant.swift
@@ -71,6 +71,25 @@ enum Quant {
         }
     }
 
+    /// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to disk.
+    /// q2-q4 measured from the 0731 GGUF metadata (ffn gate/up/down expert tensors);
+    /// the others are estimated as total weights minus ~8 GiB non-routed
+    /// (attention, embeddings, shared FFN, norms).
+    var routedExpertGiB: Double {
+        switch self {
+        case .proImatrix: return 424
+        case .q4Imatrix: return 145
+        case .q2Imatrix: return 73
+        case .q2q4Imatrix: return 82.69
+        }
+    }
+
+    /// Default SSD-streaming expert-cache budget (GiB) for this quant: keeps all but
+    /// ~15 GiB of routed experts resident; the rest stream from the GGUF on demand.
+    /// Truncates (82.69 − 15 → 67). Floor 16 so a degenerate tiny cache can never be
+    /// configured accidentally.
+    var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }
+
     /// Pre-0731 ("preview") Flash GGUF filenames this app used to download. Referenced only
     /// by the one-time migration cleanup; Pro never had a preview build.
     static let legacyPreviewFilenames = [

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -156,7 +156,9 @@ final class SupervisorService: ObservableObject {
         power: Int?,
         sessions: Int = 1,
         kvDiskDir: URL? = nil,
-        overrideWiredLimitGate: Bool = false
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
     ) {
         guard state == .idle || isErrorState else { emitBadState("start"); return }
         if let e = validateDs4Dir() { state = .error(e); return }
@@ -190,6 +192,15 @@ final class SupervisorService: ObservableObject {
             "--port", "\(port)",
             "--metal",
         ]
+        if ssdStreaming {
+            // SSD-backed expert streaming: only `ssdStreamingCacheGB` of routed experts
+            // stay resident; the rest load from the GGUF on cache miss. 0 omits the
+            // budget so ds4 picks its automatic cache.
+            args += ["--ssd-streaming"]
+            if ssdStreamingCacheGB > 0 {
+                args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+            }
+        }
         if let power { args += ["--power", "\(power)"] }
         // >1 preallocates N resident KV sessions so that many chats/agents generate at once.
         // 1 must omit the flag: ds4 treats even `--batched-session 1` as batched mode (MTP off).
@@ -302,7 +313,9 @@ final class SupervisorService: ObservableObject {
         power: Int?,
         sessions: Int = 1,
         kvDiskDir: URL? = nil,
-        overrideWiredLimitGate: Bool = false
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
     ) -> RestartResult {
         guard state == .ready || state == .starting else {
             emitBadState("restart")
@@ -312,8 +325,6 @@ final class SupervisorService: ObservableObject {
             recentLog.append("ignored 'restart': \(reason)")
             return .rejected(.blocked(reason: reason))
         }
-        // Gate BEFORE stopping: a refused restart keeps the healthy running server instead
-        // of tearing it down into an error state.
         let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions)
         switch feasibility {
         case let .blocked(reason):
@@ -329,7 +340,8 @@ final class SupervisorService: ObservableObject {
             guard let self else { return }
             self.start(
                 variant: variant, flashQuant: flashQuant, ctx: ctx, host: host, port: port, power: power,
-                sessions: sessions, kvDiskDir: kvDiskDir, overrideWiredLimitGate: overrideWiredLimitGate)
+                sessions: sessions, kvDiskDir: kvDiskDir, overrideWiredLimitGate: overrideWiredLimitGate,
+                ssdStreaming: ssdStreaming, ssdStreamingCacheGB: ssdStreamingCacheGB)
         }
         stop()
         if state == .idle {

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -68,12 +68,14 @@ final class SupervisorService: ObservableObject {
     /// Returns the launch config's feasibility. Injectable so tests don't depend on the
     /// host's RAM/sysctl state (CI runners are far smaller than any supported machine).
     typealias WiredLimitGate =
-        (_ variant: Variant, _ flashQuant: FlashQuant, _ ctx: Int, _ sessions: Int) -> Feasibility
-    static let defaultWiredLimitGate: WiredLimitGate = { variant, flashQuant, ctx, sessions in
+        (_ variant: Variant, _ flashQuant: FlashQuant, _ ctx: Int, _ sessions: Int, _ ssdStreamingCacheGB: Int) ->
+        Feasibility
+    static let defaultWiredLimitGate: WiredLimitGate = { variant, flashQuant, ctx, sessions, ssdStreamingCacheGB in
         let ram = systemRamGiB()
         return feasibility(
             ramGiB: ram, variant: variant, flashQuant: flashQuant, ctx: ctx,
-            wiredLimitMB: effectiveWiredLimitMB(ramGiB: ram), sessions: sessions)
+            wiredLimitMB: effectiveWiredLimitMB(ramGiB: ram), sessions: sessions,
+            ssdStreamingCacheGB: ssdStreamingCacheGB)
     }
     private let wiredLimitGate: WiredLimitGate
 
@@ -169,7 +171,7 @@ final class SupervisorService: ObservableObject {
         // Defense-in-depth for the popup gate: refuse configs whose GPU-wired working set
         // exceeds the effective Metal wired limit (starting anyway pages the model and
         // hangs the machine). The UI's confirmed "Start anyway" passes the override.
-        switch wiredLimitGate(variant, flashQuant, ctx, sessions) {
+        switch wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0) {
         case let .blocked(reason):
             state = .error(.configurationBlocked(reason: reason))
             return
@@ -325,7 +327,7 @@ final class SupervisorService: ObservableObject {
             recentLog.append("ignored 'restart': \(reason)")
             return .rejected(.blocked(reason: reason))
         }
-        let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions)
+        let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0)
         switch feasibility {
         case let .blocked(reason):
             recentLog.append("ignored 'restart': \(reason)")

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -91,7 +91,8 @@ struct ModelRowView: View {
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
     }
 
     /// Real NSAlert (not SwiftUI .alert, which would collapse the .window MenuBarExtra) —

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -21,7 +21,8 @@ struct ModelRowView: View {
                 ramGiB: ramGiB, variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
                 ctx: app.effectiveCtx(ramGiB: ramGiB),
                 wiredLimitMB: effectiveWiredLimitMB(ramGiB: ramGiB),
-                sessions: app.concurrentSessions)
+                sessions: app.concurrentSessions,
+                ssdStreamingCacheGB: app.ssdStreaming ? app.ssdStreamingCacheGB : 0)
             actionButton(feas)
             feasibilityNote(feas)
         }

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -68,6 +68,20 @@ struct SettingsView: View {
     private var sessionsBinding: Binding<Double> {
         Binding(get: { Double(app.concurrentSessions) }, set: { app.concurrentSessions = Int($0.rounded()) })
     }
+    private var streamingCacheBinding: Binding<Double> {
+        Binding(get: { Double(app.ssdStreamingCacheGB) }, set: { app.ssdStreamingCacheGB = Int($0.rounded()) })
+    }
+    private var streamingCacheMaxGiB: Int {
+        max(17, Int(Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant).routedExpertGiB) - 1)
+    }
+    private var streamingCaption: String {
+        let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+        let gb = app.ssdStreamingCacheGB
+        let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+        return
+            "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
+            + "Decode can be slower when the SSD must refill the cache."
+    }
     /// Context-size field as text. Always shows the active window: the override if set, else the
     /// tiered default — so the box is never blank. Backspacing it away stores 0 (auto), which the
     /// getter immediately re-renders as the default value.
@@ -164,6 +178,35 @@ struct SettingsView: View {
                             + "after slot reuse or restart. It does not reduce resident memory. "
                             + "Applies on next server start or restart.")
                 }
+            }
+
+            Section {
+            Section {
+                Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
+                if app.ssdStreaming {
+                    LabeledContent {
+                        HStack(spacing: 10) {
+                            Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
+                            Text("\(app.ssdStreamingCacheGB)")
+                                .monospacedDigit().foregroundStyle(.secondary)
+                                .frame(width: 30, alignment: .trailing)
+                        }
+                        .frame(width: 230)
+                    } label: {
+                        Text("Expert cache")
+                    }
+                    Text(streamingCaption)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } header: {
+                Text("SSD streaming")
+            } footer: {
+                Text(
+                    "Keeps only part of the routed expert weights in RAM and streams the rest "
+                        + "from disk on demand, freeing memory for other apps. "
+                        + "Applies on next server start or restart.")
             }
 
             Section {

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -246,7 +246,8 @@ struct SettingsView: View {
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
         if case let .rejected(feasibility) = result {
             RestartRejectionAlert.show(
                 feasibility,

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -183,7 +183,6 @@ struct SettingsView: View {
             }
 
             Section {
-            Section {
                 Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
                 if app.ssdStreaming {
                     LabeledContent {

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -77,7 +77,9 @@ struct SettingsView: View {
     private var streamingCaption: String {
         let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
         let gb = app.ssdStreamingCacheGB
-        let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+        // Truncates (82.69 − 67 → ~15 GiB); clamps at 0 so a saved budget larger than
+        // the current quant's experts (e.g. after switching quant) never shows negative.
+        let freed = max(0, Int(q.routedExpertGiB - Double(gb)))
         return
             "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
             + "Decode can be slower when the SSD must refill the cache."

--- a/Sources/DS4Control/Views/ThinkingModeControls.swift
+++ b/Sources/DS4Control/Views/ThinkingModeControls.swift
@@ -132,7 +132,8 @@ enum ThinkingModePrompt {
             host: app.normalizeHostForLaunch(), port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
         if result == .accepted { app.applyMaxThinkCtxBump(ramGiB: ramGiB) }
         return result
     }

--- a/Tests/DS4ControlTests/AppStateTests.swift
+++ b/Tests/DS4ControlTests/AppStateTests.swift
@@ -135,4 +135,23 @@ final class AppStateTests: XCTestCase {
             app2.requestThinkingMode(.max, currentCtx: 393_216, ramGiB: 128), .applied)
         XCTAssertEqual(app2.thinkingMode, .max)
     }
+
+    func testSsdStreamingDefaultsOnAndPersists() {
+        let name = "test.\(UUID().uuidString)"
+        let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertTrue(a1.ssdStreaming)  // default ON — frees ~15 GiB on fresh installs
+        a1.ssdStreaming = false
+        let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertFalse(a2.ssdStreaming)  // persisted
+    }
+    func testSsdStreamingCacheGBDefaultsToFree15BudgetAndPersists() {
+        let name = "test.\(UUID().uuidString)"
+        let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertEqual(
+            a1.ssdStreamingCacheGB,
+            Quant.for(a1.selectedVariant, flashQuant: a1.selectedFlashQuant).defaultStreamingCacheGB)
+        a1.ssdStreamingCacheGB = 80
+        let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertEqual(a2.ssdStreamingCacheGB, 80)  // persisted, not re-defaulted
+    }
 }

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -54,4 +54,14 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(thinking.contains(pattern))
         XCTAssertTrue(settings.contains(pattern))
     }
+
+    func testSettingsHasSsdStreamingSection() throws {
+        let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+        XCTAssertTrue(settings.contains(#""Stream expert weights from SSD""#))
+        XCTAssertTrue(settings.contains(#"Text("SSD streaming")"#))
+        XCTAssertTrue(settings.contains("ssdStreamingCacheGB"))
+        XCTAssertTrue(settings.contains("routedExpertGiB"))
+        // Caption shows the freed amount for the selected quant.
+        XCTAssertTrue(settings.contains("frees ~"))
+    }
 }

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -42,6 +42,7 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(settings.contains("if !supportsMaxThink(ramGiB: ram)"))
         XCTAssertTrue(settings.contains("Max Think requires at least 128 GiB unified memory."))
         XCTAssertTrue(settings.contains("Max Think is unavailable below 128 GiB unified memory."))
+    }
     func testModelRowStartThreadsSsdStreamingSetting() throws {
         let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
         // Both Start paths route through startServer(_:), which carries the setting.

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -42,5 +42,16 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(settings.contains("if !supportsMaxThink(ramGiB: ram)"))
         XCTAssertTrue(settings.contains("Max Think requires at least 128 GiB unified memory."))
         XCTAssertTrue(settings.contains("Max Think is unavailable below 128 GiB unified memory."))
+    func testModelRowStartThreadsSsdStreamingSetting() throws {
+        let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
+        // Both Start paths route through startServer(_:), which carries the setting.
+        XCTAssertTrue(modelRow.contains("ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"))
+    }
+    func testRestartCallSitesThreadSsdStreamingSetting() throws {
+        let thinking = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+        let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+        let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+        XCTAssertTrue(thinking.contains(pattern))
+        XCTAssertTrue(settings.contains(pattern))
     }
 }

--- a/Tests/DS4ControlTests/FeasibilityTests.swift
+++ b/Tests/DS4ControlTests/FeasibilityTests.swift
@@ -285,3 +285,17 @@ final class FeasibilityTests: XCTestCase {
     func testSystemRam() { XCTAssertGreaterThan(systemRamGiB(), 0) }
     func testWiredLimitReadable() { XCTAssertGreaterThanOrEqual(currentWiredLimitMB(), 0) }
 }
+
+extension FeasibilityTests {
+    func testRequiredWiredMBShrinksWhenSsdStreaming() {
+        // SSD streaming keeps only the expert-cache budget + non-routed weights resident,
+        // so the gate must not charge the full GGUF for routed experts.
+        let full = requiredWiredMB(variant: .flash, flashQuant: .q2, ctx: 1_000_000)
+        let streamed = requiredWiredMB(
+            variant: .flash, flashQuant: .q2, ctx: 1_000_000, ssdStreamingCacheGB: 67)
+        // q2: routed experts 73 GiB, cache 67 → ~6 GiB less resident; full is ~80.8 GiB
+        // weights vs ~74.8 resident. Expect a meaningful drop, not a full-weights charge.
+        XCTAssertLessThan(streamed, full)
+        XCTAssertGreaterThan(full - streamed, 4 * 1024)  // > ~4 GiB freed
+    }
+}

--- a/Tests/DS4ControlTests/SupervisorIntegrationTests.swift
+++ b/Tests/DS4ControlTests/SupervisorIntegrationTests.swift
@@ -171,7 +171,7 @@ final class SupervisorIntegrationTests: XCTestCase {
 
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in .standard })  // host-independent: skip the RAM/sysctl gate
+            wiredLimitGate: { _, _, _, _, _ in .standard })  // host-independent: skip the RAM/sysctl gate
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8137, power: nil)
         let ready = expectation(description: "ready")
         let token = s.$state.sink { if $0 == .ready { ready.fulfill() } }
@@ -194,7 +194,7 @@ final class SupervisorIntegrationTests: XCTestCase {
         let expectedAdvisory = expectedRequired + 1024
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in
+            wiredLimitGate: { _, _, _, _, _ in
                 .wiredLimitTooLow(requiredMB: expectedRequired, advisoryMB: expectedAdvisory)
             })
         s.start(variant: .flash, flashQuant: .q2, ctx: 393_216, host: "127.0.0.1", port: 8137, power: nil)
@@ -225,7 +225,7 @@ final class SupervisorIntegrationTests: XCTestCase {
         let rejection = Feasibility.wiredLimitTooLow(requiredMB: 100_000, advisoryMB: 110_000)
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in gateOpen ? .standard : rejection })
+            wiredLimitGate: { _, _, _, _, _ in gateOpen ? .standard : rejection })
         s.start(variant: .flash, flashQuant: .q2, ctx: 393_216, host: "127.0.0.1", port: 8137, power: nil)
         guard case .starting = s.state else { return XCTFail("expected .starting, got \(s.state)") }
         gateOpen = false

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -32,7 +32,7 @@ final class SupervisorStateMachineTests: XCTestCase {
     // adoption probe, and the real default would hit a live ds4-server on the dev machine.
     fileprivate func makeSupervisor(
         _ runner: FakeRunner, probe: @escaping (Int) async -> Data? = { _ in nil },
-        wiredLimitGate: @escaping SupervisorService.WiredLimitGate = { _, _, _, _ in .standard }
+        wiredLimitGate: @escaping SupervisorService.WiredLimitGate = { _, _, _, _, _ in .standard }
     ) throws -> SupervisorService {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(
@@ -141,7 +141,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         var gatedSessions: [Int] = []
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, _, sessions in
+            wiredLimitGate: { _, _, _, sessions, _ in
                 gatedSessions.append(sessions)
                 return .standard
             })
@@ -213,7 +213,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         let rejection = Feasibility.wiredLimitTooLow(requiredMB: 100_000, advisoryMB: 110_000)
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, ctx, _ in ctx == thinkMaxMinCtx ? rejection : .standard })
+            wiredLimitGate: { _, _, ctx, _, _ in ctx == thinkMaxMinCtx ? rejection : .standard })
         s.start(
             variant: .flash, flashQuant: .q2q4, ctx: 100_000,
             host: "127.0.0.1", port: 8000, power: nil)
@@ -248,7 +248,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         var gateCalls = 0
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, _, _ in
+            wiredLimitGate: { _, _, _, _, _ in
                 gateCalls += 1
                 return .standard
             })
@@ -286,7 +286,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         }
         let s = SupervisorService(
             ds4Dir: dir, runner: FakeRunner(),
-            wiredLimitGate: { _, _, _, _ in .standard })
+            wiredLimitGate: { _, _, _, _, _ in .standard })
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
         if case .error(.modelMissing) = s.state {} else { XCTFail("expected modelMissing, got \(s.state)") }
     }

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -290,6 +290,40 @@ final class SupervisorStateMachineTests: XCTestCase {
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
         if case .error(.modelMissing) = s.state {} else { XCTFail("expected modelMissing, got \(s.state)") }
     }
+    func testStartAddsSsdStreamingArgsWhenEnabled() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(
+            variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertEqual(
+            r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+    }
+    func testStartOmitsSsdStreamingArgsByDefault() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+    }
+    func testStartStreamingWithoutBudgetPassesToggleOnly() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(
+            variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 0)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+    }
+    func testRestartRelaunchCarriesSsdStreamingArgs() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        r.emit("ds4-server: listening on http://127.0.0.1:8000")
+        s.restart(
+            variant: .flash, flashQuant: .q2q4, ctx: 393_216, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertEqual(
+            r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+    }
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/Tests/DS4ControlTests/VariantTests.swift
+++ b/Tests/DS4ControlTests/VariantTests.swift
@@ -68,4 +68,17 @@ final class VariantTests: XCTestCase {
         XCTAssertFalse(flashQuantFits(.q4, ramGiB: 184))
         XCTAssertTrue(flashQuantFits(.q4, ramGiB: 185))
     }
+    func testRoutedExpertGiB() {
+        XCTAssertEqual(Quant.proImatrix.routedExpertGiB, 424, accuracy: 1)  // estimated: 432 − ~8 non-routed
+        XCTAssertEqual(Quant.q4Imatrix.routedExpertGiB, 145, accuracy: 1)  // estimated: 153 − ~8 non-routed
+        XCTAssertEqual(Quant.q2Imatrix.routedExpertGiB, 73, accuracy: 1)  // estimated: 81 − ~8 non-routed
+        XCTAssertEqual(Quant.q2q4Imatrix.routedExpertGiB, 82.69, accuracy: 0.01)  // MEASURED from 0731 GGUF metadata
+    }
+    func testDefaultStreamingCacheGB() {
+        // Truncating budget that leaves ~15 GiB of routed experts to stream from SSD.
+        XCTAssertEqual(Quant.proImatrix.defaultStreamingCacheGB, 409)
+        XCTAssertEqual(Quant.q4Imatrix.defaultStreamingCacheGB, 130)
+        XCTAssertEqual(Quant.q2Imatrix.defaultStreamingCacheGB, 58)
+        XCTAssertEqual(Quant.q2q4Imatrix.defaultStreamingCacheGB, 67)  // 82.69 − 15 = 67.69 → 67
+    }
 }

--- a/docs/superpowers/plans/2026-08-12-ssd-streaming.md
+++ b/docs/superpowers/plans/2026-08-12-ssd-streaming.md
@@ -1,0 +1,501 @@
+# SSD Streaming Implementation Plan (Staged)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stage 1 — ship SSD streaming for `ds4-server` in DS4 Control, default ON with an expert-cache budget that frees ~15 GiB of resident model weights (moved to SSD), exposed as a Settings toggle + slider. Stage 2 (captured, not scheduled) — multi-model support for Laguna S 2.1.
+
+**Architecture:** `ds4-server` already supports `--ssd-streaming` with an explicit `--ssd-streaming-cache-experts NGB` budget (measured model facts in the design spec: q2-q4 0731 has 82.7 GiB of routed expert weights; a 67 GB cache budget frees ~15.7 GiB; ds4's startup log reports the actual cache). The app changes are additive: a per-quant expert-size table on `Quant` (`Model/Variant.swift`), two persisted AppState settings, two defaulted params on `SupervisorService.start()/restart()`, and a new Settings section — all following existing patterns.
+
+**Tech Stack:** Swift 6, SwiftPM, SwiftUI, XCTest. Backing server: vendored `ds4-server` (Metal backend).
+
+**Design spec:** `docs/superpowers/specs/2026-08-12-ssd-streaming-design.md` (approved 2026-08-12).
+
+## Global Constraints
+
+- **Build/test commands need the SwiftUIMacros plugin workaround** on this machine: `xcode-select` points at CommandLineTools (no `libSwiftUIMacros.dylib`) and Xcode's license is unaccepted. Every `swift build` / `swift test` in this plan must use:
+
+  ```bash
+  export SWIFTUI_PLUGIN="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins/libSwiftUIMacros.dylib"
+  swift build -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"
+  swift test  -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"
+  ```
+
+  (CI on `macos-26` needs no workaround. Permanent local fix: `sudo xcode-select -s /Applications/Xcode.app` + `sudo xcodebuild -license accept`, then plain commands work.)
+- Repo root: `/Users/pauleveritt/projects/ds4-control`. Run tests from there.
+- **Follow existing patterns exactly:** AppState settings are `@Published var X { didSet { d.set(X, forKey:) } }` with read-back in `init`; SupervisorService arg tests use the file-private `FakeRunner` in `SupervisorStateMachineTests.swift`; view presence is asserted via source-containment tests (see `ChatThinkMaxToggleTests.source(_:)`).
+- CI runs `swift format lint --strict --recursive Sources Tests` — keep formatting clean (run `swift format lint --recursive Sources Tests` before committing; the project uses `.swift-format`).
+- No code changes outside the files listed per task. No Laguna work in Stage 1.
+- All test-file changes are additive; existing tests must keep passing.
+
+---
+
+## Stage 1 — SSD Streaming (the "no-Laguna" build)
+
+### Task 1: Per-quant routed-expert table + default budget
+
+**Files:**
+- Modify: `Sources/DS4Control/Model/Variant.swift` (add two members to `Quant`)
+- Test: `Tests/DS4ControlTests/VariantTests.swift`
+
+**Interfaces:**
+- Produces: `Quant.routedExpertGiB: Double` and `Quant.defaultStreamingCacheGB: Int` (truncating `Int(routedExpertGiB - 15)`, floor 16). Consumed by Tasks 2 and 5.
+
+- [ ] **Step 1: Write the failing tests** — append to `VariantTests.swift`:
+
+```swift
+func testRoutedExpertGiB() {
+    XCTAssertEqual(Quant.proImatrix.routedExpertGiB, 424, accuracy: 1)  // estimated: 432 − ~8 non-routed
+    XCTAssertEqual(Quant.q4Imatrix.routedExpertGiB, 145, accuracy: 1)  // estimated: 153 − ~8 non-routed
+    XCTAssertEqual(Quant.q2Imatrix.routedExpertGiB, 73, accuracy: 1)  // estimated: 81 − ~8 non-routed
+    XCTAssertEqual(Quant.q2q4Imatrix.routedExpertGiB, 82.69, accuracy: 0.01)  // MEASURED from 0731 GGUF metadata
+}
+func testDefaultStreamingCacheGB() {
+    // Truncating budget that leaves ~15 GiB of routed experts to stream from SSD.
+    XCTAssertEqual(Quant.proImatrix.defaultStreamingCacheGB, 409)
+    XCTAssertEqual(Quant.q4Imatrix.defaultStreamingCacheGB, 130)
+    XCTAssertEqual(Quant.q2Imatrix.defaultStreamingCacheGB, 58)
+    XCTAssertEqual(Quant.q2q4Imatrix.defaultStreamingCacheGB, 67)  // 82.69 − 15 = 67.69 → 67
+}
+```
+
+  (The floor of 16 GiB in `defaultStreamingCacheGB` is defensive only — every real quant is ≥ 73 GiB — so it is not separately unit-tested.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc -load-plugin-library "$SWIFTUI_PLUGIN" --filter VariantTests` (with `SWIFTUI_PLUGIN` exported per Global Constraints)
+Expected: FAIL — `routedExpertGiB`/`defaultStreamingCacheGB` unresolved.
+
+- [ ] **Step 3: Implement** — in `Variant.swift`, inside `enum Quant` (after `weightsGiB`):
+
+```swift
+/// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to disk.
+/// q2-q4 measured from the 0731 GGUF metadata (ffn gate/up/down expert tensors);
+/// the others are estimated as total weights minus ~8 GiB non-routed
+/// (attention, embeddings, shared FFN, norms).
+var routedExpertGiB: Double {
+    switch self {
+    case .proImatrix: return 424
+    case .q4Imatrix: return 145
+    case .q2Imatrix: return 73
+    case .q2q4Imatrix: return 82.69
+    }
+}
+
+/// Default SSD-streaming expert-cache budget (GiB) for this quant: keeps all but
+/// ~15 GiB of routed experts resident; the rest stream from the GGUF on demand.
+/// Truncates (82.69 − 15 → 67). Floor 16 so a degenerate tiny cache can never be
+/// configured accidentally.
+var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter VariantTests`
+Expected: PASS (6 tests, existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Model/Variant.swift Tests/DS4ControlTests/VariantTests.swift
+git commit -m "feat: per-quant routed-expert table for SSD streaming defaults"
+```
+
+### Task 2: AppState settings (default ON, 15 GiB-free budget)
+
+**Files:**
+- Modify: `Sources/DS4Control/AppState.swift`
+- Test: `Tests/DS4ControlTests/AppStateTests.swift`
+
+**Interfaces:**
+- Consumes: `Quant.routedExpertGiB` / `Quant.defaultStreamingCacheGB` (Task 1).
+- Produces: `AppState.ssdStreaming: Bool` (default `true`) and `AppState.ssdStreamingCacheGB: Int` (default = `Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB`). Consumed by Tasks 3–5.
+
+- [ ] **Step 1: Write the failing tests** — append to `AppStateTests.swift`:
+
+```swift
+func testSsdStreamingDefaultsOnAndPersists() {
+    let name = "test.\(UUID().uuidString)"
+    let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertTrue(a1.ssdStreaming)  // default ON — frees ~15 GiB on fresh installs
+    a1.ssdStreaming = false
+    let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertFalse(a2.ssdStreaming)  // persisted
+}
+func testSsdStreamingCacheGBDefaultsToFree15BudgetAndPersists() {
+    let name = "test.\(UUID().uuidString)"
+    let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertEqual(
+        a1.ssdStreamingCacheGB,
+        Quant.for(a1.selectedVariant, flashQuant: a1.selectedFlashQuant).defaultStreamingCacheGB)
+    a1.ssdStreamingCacheGB = 80
+    let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertEqual(a2.ssdStreamingCacheGB, 80)  // persisted, not re-defaulted
+}
+```
+
+  (The default-then-uses-machine-RAM assertion matches the existing `testEffectiveCtxFallsBackToDefault` pattern; the exact `67` for q2-q4 is asserted in Task 1.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter AppStateTests`
+Expected: FAIL — `ssdStreaming`/`ssdStreamingCacheGB` unresolved.
+
+- [ ] **Step 3: Implement** — in `AppState.swift`, add properties alongside the other `@Published` settings (after `kvDiskCache`):
+
+```swift
+/// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM; the
+/// rest stream from the GGUF on demand. Default ON with the ~15 GiB-free budget
+/// for the selected quant.
+@Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+@Published var ssdStreamingCacheGB: Int {
+    didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+}
+```
+
+  In `init`, after the `selectedVariant`/`selectedFlashQuant` read-backs (so the default can key off them):
+
+```swift
+ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true  // default on
+let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int
+ssdStreamingCacheGB =
+    storedGB ?? Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter AppStateTests`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/AppState.swift Tests/DS4ControlTests/AppStateTests.swift
+git commit -m "feat: SSD streaming AppState settings, default ON with ~15 GiB-free budget"
+```
+
+### Task 3: SupervisorService launch args
+
+**Files:**
+- Modify: `Sources/DS4Control/Services/SupervisorService.swift` (`start(...)` and `restart(...)`)
+- Test: `Tests/DS4ControlTests/SupervisorStateMachineTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new (raw `Bool`/`Int` params from callers).
+- Produces: `SupervisorService.start(variant:flashQuant:ctx:host:port:power:sessions:kvDiskDir:ssdStreaming:ssdStreamingCacheGB:)` and the matching `restart(...)` — both with `ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0` appended as defaulted params (existing callers keep compiling). Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing tests** — append to `SupervisorStateMachineTests.swift`:
+
+```swift
+func testStartAddsSsdStreamingArgsWhenEnabled() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(
+        variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertEqual(
+        r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+}
+func testStartOmitsSsdStreamingArgsByDefault() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+}
+func testStartStreamingWithoutBudgetPassesToggleOnly() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(
+        variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 0)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+}
+func testRestartRelaunchCarriesSsdStreamingArgs() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+    r.emit("ds4-server: listening on http://127.0.0.1:8000")
+    s.restart(
+        variant: .flash, flashQuant: .q2q4, ctx: 393_216, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertEqual(
+        r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter SupervisorStateMachineTests`
+Expected: FAIL — `ssdStreaming`/`ssdStreamingCacheGB` are extra arguments.
+
+- [ ] **Step 3: Implement** — in `SupervisorService.swift`, extend both signatures:
+
+```swift
+func start(
+    variant: Variant,
+    flashQuant: FlashQuant,
+    ctx: Int,
+    host: String,
+    port: Int,
+    power: Int?,
+    sessions: Int = 1,
+    kvDiskDir: URL? = nil,
+    ssdStreaming: Bool = false,
+    ssdStreamingCacheGB: Int = 0
+)
+```
+
+  and the identical param list on `restart(...)`. In `start`, right after the `--metal` line in the args assembly (before the `if let power` block):
+
+```swift
+if ssdStreaming {
+    // SSD-backed expert streaming: only `ssdStreamingCacheGB` of routed experts
+    // stay resident; the rest load from the GGUF on cache miss. 0 omits the
+    // budget so ds4 picks its automatic cache.
+    args += ["--ssd-streaming"]
+    if ssdStreamingCacheGB > 0 {
+        args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+    }
+}
+```
+
+  In `restart`, forward the two values into the `start(...)` call inside the `relaunch` closure.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter SupervisorStateMachineTests`
+Expected: PASS (existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Services/SupervisorService.swift Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+git commit -m "feat: pass --ssd-streaming and expert-cache budget to ds4-server"
+```
+
+### Task 4: Thread the setting through the four call sites
+
+**Files:**
+- Modify: `Sources/DS4Control/Views/ModelRowView.swift` (two `supervisor.start(...)` calls), `Sources/DS4Control/Views/ThinkingModeControls.swift` (one `supervisor.restart(...)` call), `Sources/DS4Control/Views/SettingsView.swift` (the `restart()` helper)
+- Test: `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift` (source-containment additions)
+
+**Interfaces:**
+- Consumes: `app.ssdStreaming`, `app.ssdStreamingCacheGB` (Task 2) and the Task 3 signatures.
+- Produces: all launch/restart paths carrying the setting.
+
+- [ ] **Step 1: Write the failing source tests** — append to `ChatThinkMaxToggleTests.swift` (the class already has the private `source(_:)` helper):
+
+```swift
+func testModelRowStartThreadsSsdStreamingSetting() throws {
+    let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
+    XCTAssertEqual(
+        modelRow.components(separatedBy: "supervisor.start(").count - 1, 2,
+        "both start call sites must pass the setting")
+    // Both call sites use identical trailing args; assert the pattern appears twice.
+    let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+    XCTAssertEqual(modelRow.components(separatedBy: pattern).count - 1, 2)
+}
+func testRestartCallSitesThreadSsdStreamingSetting() throws {
+    let thinking = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+    let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+    let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+    XCTAssertTrue(thinking.contains(pattern))
+    XCTAssertTrue(settings.contains(pattern))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter ChatThinkMaxToggleTests`
+Expected: FAIL — pattern not found.
+
+- [ ] **Step 3: Implement** — at each call site, after the existing `kvDiskDir:` argument, add:
+
+```swift
+ssdStreaming: app.ssdStreaming,
+ssdStreamingCacheGB: app.ssdStreamingCacheGB,
+```
+
+  In `ModelRowView.swift` both `supervisor.start(...)` calls get it (they are inside the `.error` retry branch and the `default` Start branch). In `ThinkingModeControls.confirmAndApply` and `SettingsView.restart()` the `supervisor.restart(...)` calls get it.
+
+- [ ] **Step 4: Verify** — run the full test suite (build + tests with the plugin flag), expected all green; run `swift format lint --recursive Sources Tests` to confirm no lint drift.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Views/ModelRowView.swift Sources/DS4Control/Views/ThinkingModeControls.swift Sources/DS4Control/Views/SettingsView.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: thread SSD streaming setting through all start/restart call sites"
+```
+
+### Task 5: Settings UI section
+
+**Files:**
+- Modify: `Sources/DS4Control/Views/SettingsView.swift`
+- Test: `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift`
+
+**Interfaces:**
+- Consumes: `AppState.ssdStreaming`, `AppState.ssdStreamingCacheGB` (Task 2), `Quant.routedExpertGiB` + existing `Quant.for(_:flashQuant:)` (Task 1).
+- Produces: the "SSD streaming" Settings section (toggle + budget slider + freed-RAM caption).
+
+- [ ] **Step 1: Write the failing source test** — append to `ChatThinkMaxToggleTests.swift`:
+
+```swift
+func testSettingsHasSsdStreamingSection() throws {
+    let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+    XCTAssertTrue(settings.contains(#""Stream expert weights from SSD""#))
+    XCTAssertTrue(settings.contains(#"Text("SSD streaming")"#))
+    XCTAssertTrue(settings.contains("ssdStreamingCacheGB"))
+    XCTAssertTrue(settings.contains("routedExpertGiB"))
+    // Caption shows the freed amount for the selected quant.
+    XCTAssertTrue(settings.contains("frees ~"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter ChatThinkMaxToggleTests`
+Expected: FAIL — strings not found.
+
+- [ ] **Step 3: Implement** — in `SettingsView.swift`:
+
+  Add computed helpers near `sessionsBinding`:
+
+```swift
+private var streamingCacheBinding: Binding<Double> {
+    Binding(get: { Double(app.ssdStreamingCacheGB) }, set: { app.ssdStreamingCacheGB = Int($0.rounded()) })
+}
+private var streamingCacheMaxGiB: Int {
+    max(17, Int(Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant).routedExpertGiB) - 1)
+}
+private var streamingCaption: String {
+    let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+    let gb = app.ssdStreamingCacheGB
+    let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+    return
+        "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
+        + "Decode can be slower when the SSD must refill the cache."
+}
+```
+
+  Insert a new section between the `Server` section and the `Apply & Restart Server` section:
+
+```swift
+Section {
+    Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
+    if app.ssdStreaming {
+        LabeledContent {
+            HStack(spacing: 10) {
+                Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
+                Text("\(app.ssdStreamingCacheGB)")
+                    .monospacedDigit().foregroundStyle(.secondary)
+                    .frame(width: 30, alignment: .trailing)
+            }
+            .frame(width: 230)
+        } label: {
+            Text("Expert cache")
+        }
+        Text(streamingCaption)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+} header: {
+    Text("SSD streaming")
+} footer: {
+    Text(
+        "Keeps only part of the routed expert weights in RAM and streams the rest "
+            + "from disk on demand, freeing memory for other apps. "
+            + "Applies on next server start or restart.")
+}
+```
+
+  (Note: the caption truncates the freed amount — `~15 GiB` for the 67 GB default — matching the default-budget formula, a deliberate deviation from the spec's rounded sketch.)
+
+- [ ] **Step 4: Verify** — full test suite green; `swift format lint --recursive Sources Tests` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Views/SettingsView.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: SSD streaming settings UI (toggle + expert-cache budget slider)"
+```
+
+### Task 6: Full build, tests, .app, and real-model verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (add an entry in the existing format)
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Full test suite**
+
+Run (from repo root, with `SWIFTUI_PLUGIN` exported):
+`swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"`
+Expected: all tests pass.
+
+- [ ] **Step 2: Release build**
+
+Run: `swift build -c release -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" -Xswiftc -warnings-as-errors`
+Expected: builds clean (CI parity).
+
+- [ ] **Step 3: Build the .app**
+
+Run (same plugin flag; `build.sh`'s own `swift build` line must be patched in a gitignored copy as was done for the initial bundle, or use the temporary wrapper at `.build/build-app.sh` from earlier — re-create it if missing by copying `build.sh` and adding the `-Xswiftc -Xfrontend -Xswiftc -load-plugin-library ...` flags to its `swift build -c release` line):
+`DS4_SRC="$PWD/external/ds4" bash .build/build-app.sh`
+Expected: `DS4 Control.app` builds, signed ad-hoc, `ds4-server` bundled.
+
+- [ ] **Step 4: Real-model launch (manual, heavy — optional but recommended)**
+
+Stop any running ds4-server first (`pkill -f ds4-server`). Launch with the exact args the app will pass for the default settings (q2-q4, 1M ctx, streaming 67 GB):
+
+```bash
+"$PWD/external/ds4/ds4-server" \
+  -m "/Users/pauleveritt/Library/Application Support/DS4 Control/gguf/DeepSeek-V4-Flash-Layers37-42Q4KExperts-OtherExpertLayersIQ2XXSGateUp-Q2KDown-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-fixed-0731.gguf" \
+  --ctx 1000000 --host 127.0.0.1 --port 8000 --metal \
+  --ssd-streaming --ssd-streaming-cache-experts 67GB \
+  --kv-disk-dir "$HOME/Library/Application Support/DS4 Control/kv" --kv-disk-space-mb 16384
+```
+
+Watch stderr for the startup cache report (grep `streaming expert cache`): it prints the actual expert budget and target GiB — the authoritative freed-amount signal. Then `ps -o rss= -p <pid>` and compare with a same-args-without-streaming launch if you want the empirical delta. Kill the server when done. (Loading the 91 GiB model takes minutes; do the comparison only if you have time for two loads.)
+
+- [ ] **Step 5: CHANGELOG**
+
+Add an entry under the top (unreleased) section, following the existing bullet style:
+`- SSD streaming (default on): keeps ~15 GiB less of the model resident by caching only part of the routed experts; budget slider in Settings.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog — SSD streaming"
+```
+
+---
+
+## Stage 2 (captured, NOT scheduled): Laguna S 2.1 support
+
+The user explicitly wants the no-Laguna build first; everything below is a scoped capture of the discussion for a future plan. **Not tasks to execute now.**
+
+**Goal (future):** let the app download and serve either DS4F (Pro/Flash) or Laguna S 2.1, with switching via the existing restart flow.
+
+### Requirements capture
+
+1. **Fork/submodule first (critical path).** The pinned submodule commit (`ebacae9`, `ds4-control-patches-v2`) predates Laguna. `laguna-s2.1` is a separate fork branch declaring a third family (`DS4_MODEL_FAMILY_LAGUNA`, 48 layers) in the same runtime-dispatched `ds4.c` (`DS4_MODEL_FAMILY`/`DS4_MODEL_VARIANT` are read from the GGUF shape at runtime — one server binary serves both, no separate build). The THINK_MAX patch must be rebased/merged onto a Laguna-capable commit, then the pin bumps and CI/release re-verified. `build.sh` needs no change (it bundles whatever the submodule has).
+2. **Downloads (DFlash explicitly SKIPPED per user).** DS4F repo: `antirez/deepseek-v4-gguf`. Laguna: `laguna-q4` → `poolside/Laguna-S-2.1-GGUF` / `laguna-s-2.1-Q4_K_M.gguf` (63.56 GiB, needs the fork's pinned `HF_REVISION` — the app's `HFDownloader` already supports `revision:`); `laguna-q2-q3` → `antirez/Laguna-S-2.1-GGUF` / `laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf` (44.95 GiB, 64 GB class). Skip `laguna-dflash` (`--dflash` speculative decoding) entirely. `SupervisorService.ggufRepo` becomes per-model repo+revision; progress totals need correct per-model `weightsGiB`.
+3. **Model table.** `Variant`/`FlashQuant` generalize into a model-family × quant structure: per-family `modelId`, layers (Laguna 48), `kvBytesPerToken`, `ctxCeiling` (Laguna ≠ 1M; likely far smaller — verify model card), quants, GGUF names, repo+revision, `routedExpertGiB` (below).
+4. **KV/ctx math must be re-measured.** `kvBytesPerToken = layers × 391` was measured for DS4F Flash only (via `scripts/flash-mem-harness.sh`); Laguna's attention (SWA layers) differs and needs its own harness run before `defaultCtx`/RAM budgets can be trusted.
+5. **Reasoning/thinking semantics.** The chat's `reasoning_content` section, Think-Max tiers (393,216 floor, `THINK_MAX` env), and the agent launcher's Max-Think prompt are DS4-specific. Laguna advertises native interleaved reasoning — verify SSE shape and prompts against a real server before reusing them.
+6. **Feasibility tier for true 64 GB class.** The app currently blocks <96 GiB. Laguna q2-q3 (44.95 GiB weights) targets 64 GB laptops: new tier + the existing wired-limit advisory math (with the 8 GiB OS reserve, weights + modest KV ≈ 55–57 GiB — tight but feasible).
+7. **SSD-streaming table.** Add measured `routedExpertGiB` for Laguna quants. q2-q3 is a *mixed* routed quant (Q2_K, last 27 layers Q3_K) — the same "boosted layers can't use the single-size-class expert cache" caveat as DS4F q2-q4; the Settings freed-RAM caption follows.
+8. **Chat model identity.** `ChatViewModel(model: app.selectedVariant.modelId, ...)` captures the id at launch; multi-model switching needs it bound to the running server (the `/v1/models` `loadedModelName` path already does this for adopted servers).
+9. **Shared KV cache — NOT a blocker.** On-disk KV entries are namespaced by `model_id` + `quant_bits` (`ds4_kvstore.c` rejects mismatches), so DS4F/Laguna never replay each other's prefixes in the shared `App Support/DS4 Control/kv` dir; the only shared effect is the 16 GiB `--kv-disk-space-mb` budget (mutual eviction, harmless). Optional clean split: per-family `kv/<family>` subdirs. No custom `$HOME` needed for the server.
+10. **Cleanup/migration generalization.** `cleanupUnusedFlashQuants` and the pre-0731 legacy-gguf banner are DS4F-shaped; new family files must be excluded and the loops generalized.
+11. **Tests.** Feasibility/ctx math for the new tier, downloader tests for the second repo+revision, a Laguna KV harness, and the existing `VariantTests`/`AppStateTests` extended for the family table.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every design-spec decision maps to a task — per-quant table (T1), AppState defaults/persistence (T2), arg construction incl. the 0-budget edge (T3), all four call sites (T4), Settings UI with freed-RAM caption (T5), full verification + changelog (T6). Out-of-scope items (feasibility relaxation, cold/preload knobs, per-quant persisted budgets) are deliberately absent. Laguna points are fully captured in Stage 2 with DFlash excluded.
+- **Placeholder scan:** no TBD/TODO; every step has concrete code or commands. The one "re-create if missing" reference (`.build/build-app.sh`) names the exact recipe to rebuild it.
+- **Type consistency:** `routedExpertGiB` (T1) is consumed by T2 (via `Quant.for`) and T5; `ssdStreaming`/`ssdStreamingCacheGB` names are identical across T2–T5; Task 3 signatures use exactly `ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0`; test values (67GB, 67, 409/130/58/67) match the truncating formula throughout.

--- a/docs/superpowers/specs/2026-08-12-ssd-streaming-design.md
+++ b/docs/superpowers/specs/2026-08-12-ssd-streaming-design.md
@@ -1,0 +1,158 @@
+# SSD Streaming Support — Design
+
+**Date:** 2026-08-12
+**Status:** Approved (2026-08-12)
+
+## Goal
+
+Let ds4-control run `ds4-server` with SSD streaming enabled by default, freeing
+~15 GiB of resident model weights (moved to SSD). Expose it as a Settings
+toggle with an expert-cache budget slider, defaulted to the value that frees
+~15 GiB on the selected model.
+
+## Background
+
+`ds4-server` (antirez/ds4, vendored at `external/ds4`) supports SSD-backed
+model streaming (`--ssd-streaming`): non-routed weights stay resident while
+routed MoE experts live in an in-memory cache and load from the GGUF on cache
+misses. The routed-expert cache budget is `--ssd-streaming-cache-experts
+NGB` (memory budget) or `N` (exact expert count). A plain `--ssd-streaming`
+uses an automatic budget of 80% of the backend's recommended working set
+minus non-routed weights — on this machine (M5 Max, 128 GiB, Metal
+recommended working set 107.5 GiB) that frees only ~5 GiB, so an explicit
+budget is required to reach the ~15 GiB target.
+
+### Measured model facts (q2-q4 0731, the default on ≥128 GiB machines)
+
+Parsed from the downloaded GGUF metadata (`DeepSeek-V4-Flash-...-fixed-0731.gguf`):
+
+| Tensor family | Size |
+|---|---|
+| `ffn_down_exps` (routed) | 31.0 GiB |
+| `ffn_gate_exps` (routed) | 25.8 GiB |
+| `ffn_up_exps` (routed) | 25.8 GiB |
+| **Total routed experts** | **82.7 GiB** |
+| Non-routed (attn, embeddings, shared FFN, norms) | ~8.3 GiB |
+| Total | ~91 GiB (matches file size) |
+
+Freeing ~15 GiB ⇒ expert-cache budget ≈ **67 GB**
+(`--ssd-streaming-cache-experts 67GB`), freeing 82.7 − 67 ≈ 15.7 GiB. ds4 may
+cap an explicit budget down (7/8 of recommended working set minus context
+memory), which only increases the amount freed; its startup log reports the
+actual cache size ("streaming expert cache budget=… target=… GiB").
+
+## Decisions
+
+- **Default ON.** Fresh installs run with SSD streaming enabled and the
+  ~15 GiB-free budget. Users can toggle off or dial the budget back toward
+  "keep more in RAM" if cache-miss decode feels slow.
+- **Per-quant default budget** so "frees ~15 GiB" holds for any Flash quant
+  (q2: 58 GB, q2-q4: 67 GB, q4: 130 GB) and Pro (409 GB). Derived from a
+  small hardcoded `routedExpertGiB` table on `Quant` (q2-q4 measured from the
+  GGUF; others estimated as weights minus ~8 GiB non-routed).
+- **One persisted budget value** (not per-quant keyed). If the user changes
+  quant, the saved budget is kept — their explicit choice. The Settings
+  caption shows the effective freed amount for the currently selected quant.
+- **UI lives in Settings** (matches existing Toggle+Slider row pattern),
+  applied by the existing Apply/Restart flow. No popup changes.
+- **Out of scope:** relaxing the RAM feasibility gate to run Pro below
+  512 GiB (ds4 supports streaming Pro on 128 GiB, but not requested);
+  `--ssd-streaming-cold` / `--ssd-streaming-preload-experts` (measurement-only);
+  per-quant persisted budgets; runtime GGUF parsing for exact expert bytes
+  (ds4's log + safety cap absorb estimation error).
+
+## Changes
+
+### 1. `Model/Variant.swift`
+
+Add to `Quant`:
+
+```swift
+/// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to
+/// disk. q2-q4 measured from the 0731 GGUF metadata; others estimated as
+/// total weights minus ~8 GiB non-routed (attn/embeddings/shared FFN).
+var routedExpertGiB: Double {
+    switch self {
+    case .proImatrix: return 424
+    case .q4Imatrix: return 145
+    case .q2Imatrix: return 73
+    case .q2q4Imatrix: return 82.69
+    }
+}
+
+/// Default SSD-streaming expert-cache budget (GiB) for this quant: leaves
+/// ~15 GiB of resident routed experts to stream from SSD. Floor 16 GiB so a
+/// degenerate tiny cache can never be configured accidentally.
+var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }  // truncates: 82.69−15 → 67
+```
+
+### 2. `AppState.swift`
+
+Follow the existing `@Published` + `didSet` persistence pattern:
+
+```swift
+/// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM;
+/// the rest stream from the GGUF on demand. Default ON with the ~15 GiB-free
+/// budget for the default quant.
+@Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+@Published var ssdStreamingCacheGB: Int {
+    didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+}
+```
+
+`init` read-back: `ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true`
+(default on); `ssdStreamingCacheGB` defaults to
+`Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB`
+when unset (compute after the quant/variant read-backs), else the stored value.
+
+### 3. `Services/SupervisorService.swift`
+
+Extend `start(...)` and `restart(...)` with defaulted params
+`ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0`. In the args
+assembly (after the `--metal` block):
+
+```swift
+if ssdStreaming {
+    args += ["--ssd-streaming"]
+    if ssdStreamingCacheGB > 0 {
+        args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+    }
+}
+```
+
+### 4. Call sites (thread `app.ssdStreaming` / `app.ssdStreamingCacheGB`)
+
+- `Views/ModelRowView.swift` — two `supervisor.start(...)` calls
+- `Views/ThinkingModeControls.swift` — one `supervisor.restart(...)` call
+- `Views/SettingsView.swift` — `restart()` helper
+
+### 5. `Views/SettingsView.swift` — new section
+
+New section following the existing Toggle + Slider row pattern:
+
+- Toggle: "Stream expert weights from SSD"
+- When on: slider, range `16...(max(17, Int(quant.routedExpertGiB) - 1))`, step 1,
+  plus a caption computing freed RAM for the currently selected quant:
+  `"Expert cache \(gb) GiB — frees ~\(Int((quant.routedExpertGiB - Double(gb)).rounded())) GiB of RAM. Decode can be slower when the SSD must refill the cache."`
+- Footer note explaining the tradeoff; changes apply via the existing
+  Apply/Restart flow.
+
+## Tests
+
+- `SupervisorStateMachineTests` (or the existing fake-runner integration
+  tests): `start` with `ssdStreaming: true, ssdStreamingCacheGB: 67` passes
+  `--ssd-streaming` and `--ssd-streaming-cache-experts 67GB`; with `false`
+  passes neither.
+- `VariantTests`: `defaultStreamingCacheGB` per quant (q2-q4 → 67, q2 → 58,
+  q4 → 130, pro → 409); floor of 16.
+- `AppState` default assertions: fresh install → `ssdStreaming == true`,
+  `ssdStreamingCacheGB == 67` (default quant q2-q4 on ≥128 GiB).
+- All existing tests keep passing (new params defaulted).
+
+## Manual verification
+
+Launch `ds4-server` with the real q2-q4 model and the flags
+(`-m <gguf> --ctx 1000000 --metal --ssd-streaming
+--ssd-streaming-cache-experts 67GB`), read the startup cache report line, and
+compare resident memory vs. a non-streaming launch: expect ~15 GiB less
+resident RAM. The app's stderr tail (`recentLog`) surfaces the same report.


### PR DESCRIPTION
## What

Runs `ds4-server` with `--ssd-streaming` + an expert-cache budget, **on by default**, freeing ~15 GiB of resident model weights (routed MoE experts cache in RAM, the rest stream from the GGUF on demand).

## Why

Headroom on RAM-constrained Macs. ds4's *automatic* budget only frees ~5 GiB on this class of machine; an explicit budget is needed to reach ~15 GiB.

## How

- **Per-quant routed-expert table** (`Quant.routedExpertGiB`) measured from the actual GGUF metadata — q2-q4 0731: 82.69 GiB routed (gate/up/down); others estimated. `defaultStreamingCacheGB = expertGiB − 15` → **67 GB** for q2-q4.
- **AppState** `ssdStreaming` (default **on**) + `ssdStreamingCacheGB` (default = the ~15 GiB-free budget), persisted like the other prefs.
- **Launch args** `--ssd-streaming` + `--ssd-streaming-cache-experts <N>GB` threaded through all start/restart paths.
- **Settings UI**: toggle + GiB slider with a live "frees ~N GiB" caption.
- **SSD-aware Metal wired-limit gate**: `requiredWiredMB` charges *resident* weights (non-routed + cache budget) instead of the full GGUF when streaming is on — so the #15 gate doesn't over-fire for streamed configs.

## Verification

- 210 tests (fake-runner arg assertions, per-quant math, AppState defaults, source tests)
- Live boot: q2-q4 @1M with 67 GB budget → ds4 reports `budget 67.00 GiB = 3.38 prefill + 62.44 dynamic (9472 experts)`, planned memory **82.45 GiB vs ~107 all-resident**; server healthy, generated end-to-end.

Docs: `docs/superpowers/specs/2026-08-12-ssd-streaming-design.md` (+ TDD plan in `docs/superpowers/plans/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSD expert-weight streaming, enabled by default.
  * Reduced model memory residency by approximately 15 GiB through partial expert caching.
  * Added Settings controls to disable streaming and adjust the SSD cache size.
  * Streaming preferences are now saved and restored across launches and restarts.
  * Memory checks and server startup behavior now account for the selected streaming configuration.

* **Documentation**
  * Added documentation and design details for SSD streaming configuration and behavior.

* **Tests**
  * Added coverage for defaults, persistence, memory estimates, launch options, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->