### PR TITLE
feat: server token-speed widget (decode/prefill tok/s from ds4-server logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It launches, supervises, and monitors a local ds4 server, lets you pick **V4 Pro
 - **Start / stop / monitor** the local `ds4-server` child process — spawn, stderr readiness detection, health polling, graceful stop, and crash detection.
 - **Pro / Flash selector** with a RAM feasibility gate.
 - **Model downloads** via a built-in native parallel downloader, with a live progress bar and resume across restarts.
-- **Mini resource widgets**: unified memory, GPU, power, and CPU, sampled on a timer.
+- **Mini resource widgets**: unified memory, GPU, power, CPU, and server token speed (decode/prefill tok/s read from ds4-server's own logs), sampled on a timer.
 - **Launch Chat** to talk to the model.
 - **Launch Claude Code or Pi** to plan, write, maintain or refactor code.
 - **1M Context** configurable in settings.

--- a/Sources/DS4Control/Services/ServerSpeedParser.swift
+++ b/Sources/DS4Control/Services/ServerSpeedParser.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// One server-side generation-speed sample parsed from ds4-server's stderr.
+struct ServerSpeedSnapshot: Equatable {
+    enum Phase: Equatable {
+        case prefill, decode, idle
+    }
+    var phase: Phase
+    /// tokens/sec from the line's `avg=` value (prefill/decode).
+    var tokensPerSecond: Double?
+    /// Completed/decoded token count from `gen=N`.
+    var tokens: Int?
+}
+
+/// Pure parser for ds4-server's per-request stderr timing lines (covers built-in
+/// chat AND coding agents, since it reads the server's own log):
+///
+///   "… chat ctx=0..52:52 prefill chunk 52/52 (100.0%) chunk=0.00 t/s avg=67.91 t/s 0.766s"
+///   "… chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s"
+///   "… chat ctx=0..52:52 gen=5 finish=stop 0.887s"
+///
+/// Returns a snapshot for matching lines, nil otherwise. The per-batch
+/// `decode batch count=…` lines are deliberately ignored (MTP batches, and
+/// multi-session requests interleave on them); the per-request lines are the
+/// clean tok/s signal.
+enum ServerSpeedParser {
+    private static let decodeRegex = try! NSRegularExpression(
+        pattern: #"gen=(\d+) decoding chunk=[\d.]+ t/s avg=([\d.]+) t/s"#)
+    private static let prefillRegex = try! NSRegularExpression(
+        pattern: #"prefill chunk \S+ \(\d+(?:\.\d+)?%\) chunk=[\d.]+ t/s avg=([\d.]+) t/s"#)
+    private static let finishRegex = try! NSRegularExpression(
+        pattern: #"gen=(\d+) finish=\S+"#)
+
+    static func feed(_ line: String) -> ServerSpeedSnapshot? {
+        let ns = line as NSString
+        let full = NSRange(location: 0, length: ns.length)
+        if let m = decodeRegex.firstMatch(in: line, range: full),
+            let n = Int(m.capture(1, in: line)),
+            let tps = Double(m.capture(2, in: line))
+        {
+            return ServerSpeedSnapshot(phase: .decode, tokensPerSecond: tps, tokens: n)
+        }
+        if let m = prefillRegex.firstMatch(in: line, range: full),
+            let tps = Double(m.capture(1, in: line))
+        {
+            return ServerSpeedSnapshot(phase: .prefill, tokensPerSecond: tps, tokens: nil)
+        }
+        if let m = finishRegex.firstMatch(in: line, range: full),
+            let n = Int(m.capture(1, in: line))
+        {
+            return ServerSpeedSnapshot(phase: .idle, tokensPerSecond: nil, tokens: n)
+        }
+        return nil
+    }
+}
+
+private extension NSTextCheckingResult {
+    func capture(_ idx: Int, in string: String) -> String {
+        guard idx < numberOfRanges else { return "" }
+        let r = range(at: idx)
+        guard r.location != NSNotFound else { return "" }
+        return (string as NSString).substring(with: r)
+    }
+}

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -31,6 +31,12 @@ final class SupervisorService: ObservableObject {
     /// Bumped whenever the on-disk gguf set changes via cleanup, so SwiftUI views that read
     /// `isFlashQuantDownloaded` (the Settings picker) re-render.
     @Published private(set) var ggufStoreVersion = 0
+    /// Last server-side generation speed parsed from ds4-server's per-request stderr
+    /// timing lines (covers the built-in chat AND coding agents). Nil until the first
+    /// timing line; `.idle` after a `finish=` line.
+    @Published private(set) var serverSpeed: ServerSpeedSnapshot?
+    /// Rolling (timestamp, tok/s) samples for the popup sparkline, capped to the last 60.
+    @Published private(set) var serverSpeedHistory: [(Date, Double)] = []
 
     let ds4Dir: URL
     let runner: ProcessRunner
@@ -183,6 +189,7 @@ final class SupervisorService: ObservableObject {
         }
         self.port = port; self.ctx = ctx; self.activeModel = variant.modelId
         stderrTail = []; expectingExit = false; serverAttached = false
+        serverSpeed = nil; serverSpeedHistory = []
         var args = [
             "-m", gguf.path,
             "--ctx", "\(ctx)",
@@ -223,6 +230,15 @@ final class SupervisorService: ObservableObject {
     private func handleStderr(_ line: String) {
         recentLog.append(line); stderrTail.append(line)
         if stderrTail.count > 50 { stderrTail.removeFirst(stderrTail.count - 50) }
+        if let snap = ServerSpeedParser.feed(line) {
+            serverSpeed = snap
+            if let tps = snap.tokensPerSecond {
+                serverSpeedHistory.append((Date(), tps))
+                if serverSpeedHistory.count > 60 {
+                    serverSpeedHistory.removeFirst(serverSpeedHistory.count - 60)
+                }
+            }
+        }
         if state == .starting, isReadyLine(line) {
             startupTimer?.invalidate(); startupTimer = nil
             state = .ready
@@ -250,6 +266,7 @@ final class SupervisorService: ObservableObject {
         guard state == .ready || state == .starting else { emitBadState("stop"); return }
         expectingExit = true
         state = .stopping
+        serverSpeed = nil; serverSpeedHistory = []
         healthTimer?.invalidate(); healthTimer = nil
         startupTimer?.invalidate(); startupTimer = nil
         if serverAttached {

--- a/Sources/DS4Control/Views/PopupView.swift
+++ b/Sources/DS4Control/Views/PopupView.swift
@@ -60,6 +60,13 @@ struct PopupView: View {
                 sparklineData: metrics.history.memory(), accentColor: .blue,
                 sparklineFixedRange: (0, 100), emphasized: true, gaugeFraction: s.memory.usagePercent / 100,
                 severityColorOverride: s.memory.usagePercent >= 95 ? .yellow : nil)
+            MetricCardView(
+                title: "Server", icon: "speedometer",
+                value: serverSpeedValue, subtitle: serverSpeedSubtitle,
+                severity: .normal,
+                sparklineData: supervisor.serverSpeedHistory,
+                accentColor: .teal,
+                compact: true)
             HStack(spacing: 10) {
                 MetricCardView(
                     title: "GPU", icon: "cpu",
@@ -282,6 +289,24 @@ struct PopupView: View {
     }
 
     private func gb(_ b: UInt64) -> String { String(format: "%.0f GB", Double(b) / 1_073_741_824) }
+    /// "41 tok/s" while decoding/prefilling, "idle" after a finish, "—" before any activity.
+    private var serverSpeedValue: String {
+        guard let s = supervisor.serverSpeed else { return "—" }
+        switch s.phase {
+        case .prefill, .decode:
+            return s.tokensPerSecond.map { "\(Int($0.rounded())) tok/s" } ?? "active"
+        case .idle:
+            return "idle"
+        }
+    }
+    private var serverSpeedSubtitle: String {
+        guard let s = supervisor.serverSpeed else { return "no activity yet" }
+        switch s.phase {
+        case .decode: return s.tokens.map { "decode · \($0) tok" } ?? "decode"
+        case .prefill: return "prefill"
+        case .idle: return "server idle"
+        }
+    }
     private var stateColor: Color {
         switch supervisor.state {
         case .ready: return .green

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -43,4 +43,12 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(settings.contains("Max Think requires at least 128 GiB unified memory."))
         XCTAssertTrue(settings.contains("Max Think is unavailable below 128 GiB unified memory."))
     }
+
+    func testPopupHasServerSpeedCard() throws {
+        let popup = try source("Sources/DS4Control/Views/PopupView.swift")
+        XCTAssertTrue(popup.contains(#""Server", icon: "speedometer""#))
+        XCTAssertTrue(popup.contains("serverSpeedHistory"))
+        XCTAssertTrue(popup.contains("serverSpeedValue"))
+        XCTAssertTrue(popup.contains("serverSpeedSubtitle"))
+    }
 }

--- a/Tests/DS4ControlTests/ServerSpeedParserTests.swift
+++ b/Tests/DS4ControlTests/ServerSpeedParserTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import DS4Control
+
+final class ServerSpeedParserTests: XCTestCase {
+    func testPrefillLine() {
+        let s = ServerSpeedParser.feed(
+            "0812 20:57:47 ds4-server: chat ctx=0..52:52 prefill chunk 52/52 (100.0%) chunk=0.00 t/s avg=67.91 t/s 0.766s"
+        )
+        XCTAssertEqual(s?.phase, .prefill)
+        XCTAssertEqual(s?.tokensPerSecond ?? 0, 67.91, accuracy: 0.01)
+        XCTAssertNil(s?.tokens)
+    }
+    func testDecodeLine() {
+        let s = ServerSpeedParser.feed(
+            "0812 20:57:47 ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s")
+        XCTAssertEqual(s?.phase, .decode)
+        XCTAssertEqual(s?.tokensPerSecond ?? 0, 41.40, accuracy: 0.01)
+        XCTAssertEqual(s?.tokens, 5)
+    }
+    func testFinishLine() {
+        let s = ServerSpeedParser.feed(
+            "0812 20:57:47 ds4-server: chat ctx=0..52:52 gen=5 finish=stop 0.887s")
+        XCTAssertEqual(s?.phase, .idle)
+        XCTAssertNil(s?.tokensPerSecond)
+        XCTAssertEqual(s?.tokens, 5)
+    }
+    func testNonTimingLinesReturnNil() {
+        XCTAssertNil(ServerSpeedParser.feed("ds4-server: listening on http://127.0.0.1:8000"))
+        XCTAssertNil(ServerSpeedParser.feed("ds4: metal backend initialized for graph diagnostics"))
+        // MTP batch lines are deliberately ignored: per-request lines are the clean signal.
+        XCTAssertNil(ServerSpeedParser.feed("ds4-server: decode batch count=5 elapsed=12.0 ms status=ok"))
+        XCTAssertNil(ServerSpeedParser.feed(""))
+    }
+}

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -290,6 +290,38 @@ final class SupervisorStateMachineTests: XCTestCase {
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
         if case .error(.modelMissing) = s.state {} else { XCTFail("expected modelMissing, got \(s.state)") }
     }
+    func testServerSpeedParsedFromStderrLines() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        XCTAssertNil(s.serverSpeed)  // nothing parsed yet
+        r.emit("ds4-server: chat ctx=0..52:52 prefill chunk 52/52 (100.0%) chunk=0.00 t/s avg=67.91 t/s 0.766s")
+        XCTAssertEqual(s.serverSpeed?.phase, .prefill)
+        XCTAssertEqual(s.serverSpeed?.tokensPerSecond ?? 0, 67.91, accuracy: 0.01)
+        r.emit("ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s")
+        XCTAssertEqual(s.serverSpeed?.phase, .decode)
+        XCTAssertEqual(s.serverSpeed?.tokens, 5)
+        XCTAssertEqual(s.serverSpeed?.tokensPerSecond ?? 0, 41.40, accuracy: 0.01)
+        XCTAssertEqual(s.serverSpeedHistory.count, 2)  // prefill + decode samples
+        r.emit("ds4-server: chat ctx=0..52:52 gen=5 finish=stop 0.887s")
+        XCTAssertEqual(s.serverSpeed?.phase, .idle)
+        // Non-timing lines leave the snapshot untouched.
+        r.emit("ds4-server: some other log line")
+        XCTAssertEqual(s.serverSpeed?.phase, .idle)
+    }
+    func testServerSpeedHistoryCapsAndResetsOnStart() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        let decodeLine =
+            "ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s"
+        for _ in 0..<70 { r.emit(decodeLine) }
+        XCTAssertEqual(s.serverSpeedHistory.count, 60)  // capped
+        r.crash(1)  // server dies
+        // A fresh start clears the stale speed/history.
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        XCTAssertNil(s.serverSpeed)
+        XCTAssertTrue(s.serverSpeedHistory.isEmpty)
+    }
+
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/docs/superpowers/specs/2026-08-12-server-speed-widget-design.md
+++ b/docs/superpowers/specs/2026-08-12-server-speed-widget-design.md
@@ -1,0 +1,47 @@
+# Server Token-Speed Widget — Design
+
+**Date:** 2026-08-12
+
+## Goal
+
+Show the live token-generation speed of the local `ds4-server` in the menu-bar
+popup as a compact widget — covering the built-in chat **and** coding agents,
+since the data comes from the server's own logs, not client measurement.
+
+## How it works
+
+`ds4-server` already prints per-request timing to stderr (the same stream the
+supervisor tails for readiness detection):
+
+```
+ds4-server: chat ctx=0..52:52 prefill chunk 52/52 (100.0%) chunk=0.00 t/s avg=67.91 t/s 0.766s
+ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s
+ds4-server: chat ctx=0..52:52 gen=5 finish=stop 0.887s
+```
+
+`ServerSpeedParser` (a pure type, sibling of `ReadinessMatcher`) extracts:
+- `prefill … avg=X t/s` → prefill rate
+- `gen=N decoding … avg=Y t/s` → decode rate + token count
+- `gen=N finish=stop` → idle
+
+The MTP `decode batch count=…` lines are deliberately ignored — they interleave
+requests across concurrent sessions; the per-request lines are the clean signal.
+
+`SupervisorService` publishes `serverSpeed` (phase/tps/tokens) and a capped
+rolling `serverSpeedHistory` (last 60 (timestamp, tok/s) samples) from
+`handleStderr`, reset on start/stop. The popup's "Server" card renders the
+current rate with a sparkline.
+
+## Scope / limitations
+
+- It's a **"last request's speed"** gauge (decays to idle on `finish=`), not a
+  live per-token ticker mid-generation — that would need client-side chat
+  measurement.
+- No server API changes; the data source is the existing stderr stream.
+
+## Files
+
+- `Services/ServerSpeedParser.swift` (new) — pure parser
+- `Services/SupervisorService.swift` — published `serverSpeed` / `serverSpeedHistory`
+- `Views/PopupView.swift` — the "Server" card
+- Tests: `ServerSpeedParserTests.swift`, supervisor feed/cap/reset tests, popup source test


### PR DESCRIPTION
## What

A compact **"Server" card** in the menu-bar popup showing live decode/prefill **tok/s** with a sparkline, read from ds4-server's own stderr timing lines.

## Why

The existing per-reply stat is chat-only. This is **server-side** data, so it covers the built-in chat *and* coding agents (pi/claude) alike.

## How

- `ServerSpeedParser` (pure, sibling of `ReadinessMatcher`) parses ds4's per-request lines:
  - `… prefill … avg=X t/s` → prefill rate
  - `… gen=N decoding … avg=Y t/s` → decode rate + tokens
  - `… gen=N finish=stop` → idle
  - (MTP `decode batch count=` lines deliberately ignored — noisy, multi-session)
- `SupervisorService` publishes `serverSpeed` + a capped rolling history for the sparkline, fed from the stderr it already tails; reset on start/stop.
- Popup card renders the current rate with the existing `SparklineView`.

## Verification

- 205 tests (parser against real log lines, supervisor feed/cap/reset, popup source test)
- Live: ~56 tok/s on a Laguna run, ~41 tok/s on DS4F.

Docs: `docs/superpowers/specs/2026-08-12-server-speed-widget-design.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Server card showing token generation speed, including prefill, decode, idle, and unavailable states.
  * Added a capped history of recent token-speed samples for server activity insights.

* **Documentation**
  * Updated resource widget documentation to describe decode and prefill token-speed metrics.

* **Tests**
  * Added coverage for speed parsing, display behavior, history limits, and state resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->