### PR TITLE
feat: Laguna S 2.1 (q2-q3) support — model picker, download, serve, chat, agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ It launches, supervises, and monitors a local ds4 server, lets you pick **V4 Pro
 
 - **Start / stop / monitor** the local `ds4-server` child process — spawn, stderr readiness detection, health polling, graceful stop, and crash detection.
 - **Pro / Flash selector** with a RAM feasibility gate.
+- **SSD streaming** (on by default): keeps ~15 GiB less of the model resident by caching only part of the routed experts; budget adjustable in Settings.
 - **Model downloads** via a built-in native parallel downloader, with a live progress bar and resume across restarts.
 - **Mini resource widgets**: unified memory, GPU, power, and CPU, sampled on a timer.
 - **Launch Chat** to talk to the model.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It launches, supervises, and monitors a local ds4 server, lets you pick **V4 Pro
 ## What it does
 
 - **Start / stop / monitor** the local `ds4-server` child process — spawn, stderr readiness detection, health polling, graceful stop, and crash detection.
-- **Pro / Flash selector** with a RAM feasibility gate.
+- **Model selector** — V4 Pro / V4 Flash / Laguna S 2.1, with a RAM feasibility gate.
 - **SSD streaming** (on by default): keeps ~15 GiB less of the model resident by caching only part of the routed experts; budget adjustable in Settings.
 - **Model downloads** via a built-in native parallel downloader, with a live progress bar and resume across restarts.
 - **Mini resource widgets**: unified memory, GPU, power, and CPU, sampled on a timer.
@@ -69,6 +69,7 @@ DeepSeek V4 is memory-hungry so DS4 Control gates feasibility before launching.
 | V4 Pro | pro-imatrix | **≥ 512 GiB required** | Anything below is blocked. |
 | V4 Flash (0731) | q4-imatrix | ≥ 256 GiB | Standard. |
 | V4 Flash (0731) | q2-imatrix | 96 GiB minimum | 96–127 GiB requires raising the Metal wired limit (see below). |
+| Laguna S 2.1 | q2-q3 | 64 GiB minimum | The 64 GB-laptop option; 64–95 GiB requires raising the Metal wired limit. |
 
 On any machine where the model's GPU-wired working set (the exact GGUF plus ds4's resident context, Metal graph allocations, and persistent backend scratch, including one prefill workspace and one indexer top-k scratch buffer shared across concurrent sessions) exceeds the **effective Metal wired limit**, Start is gated. Configurations that cannot fit while leaving ~4 GiB for macOS are blocked instead of being offered an unsafe wired-limit increase. The disk KV cache does not shrink this working set: ds4 preallocates every resident session's context, while disk caching only checkpoints those sessions for reuse after a slot switch or server restart. The effective limit is your `iogpu.wired_limit_mb` when raised, else the macOS default — a machine-specific fraction of RAM (~75–84% depending on macOS version) that DS4 Control queries from Metal rather than assumes. When gated, the popup shows the required fix:
 

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -49,27 +49,6 @@ final class AppState: ObservableObject {
     @Published var selectedModel: Model {
         didSet { d.set(selectedModel.rawValue, forKey: "selectedModel") }
     }
-    /// Compatibility shims over `selectedModel` (removed once the unified picker lands).
-    var selectedVariant: Variant {
-        get { selectedModel == .v4Pro ? .pro : .flash }
-        set { selectedModel = newValue == .pro ? .v4Pro : .v4FlashQ2Q4 }
-    }
-    var selectedFlashQuant: FlashQuant {
-        get {
-            switch selectedModel.quant {
-            case .q4Imatrix: return .q4
-            case .q2Imatrix: return .q2
-            default: return .q2q4
-            }
-        }
-        set {
-            switch newValue {
-            case .q2: selectedModel = .v4FlashQ2
-            case .q4: selectedModel = .v4FlashQ4
-            case .q2q4: selectedModel = selectedModel == .v4Pro ? .v4Pro : .v4FlashQ2Q4
-            }
-        }
-    }
 
     init(defaults: UserDefaults = .standard, ramGiB: Double = systemRamGiB()) {
         self.d = defaults
@@ -118,7 +97,7 @@ final class AppState: ObservableObject {
     /// First-launch model selection: the legacy selectedVariant/selectedFlashQuant keys
     /// migrate into `selectedModel`; otherwise tier by RAM (Pro ≥512, Flash q2-q4 ≥128,
     /// Flash q2 96–127, Laguna below — the only feasible model on 64 GB-class machines).
-    static func migrateLegacySelection(defaults d: UserDefaults, ramGiB: Double) -> Model {
+    nonisolated static func migrateLegacySelection(defaults d: UserDefaults, ramGiB: Double) -> Model {
         if let v = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:)),
             let f = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
         {
@@ -134,9 +113,8 @@ final class AppState: ObservableObject {
 
     func effectiveCtx(ramGiB: Double) -> Int {
         ctxOverride > 0
-            ? min(ctxOverride, selectedVariant.ctxCeiling)
-            : defaultCtx(ramGiB: ramGiB, variant: selectedVariant, flashQuant: selectedFlashQuant)
-    }
+            ? min(ctxOverride, selectedModel.ctxCeiling)
+            : defaultCtx(ramGiB: ramGiB, model: selectedModel)    }
 
     /// Set the chat's thinking level. Max is unavailable below 128 GiB and otherwise needs
     /// context ≥ 393,216. Rejections leave the current mode unchanged.

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -16,6 +16,13 @@ final class AppState: ObservableObject {
     /// keeping the original single-session path. Memory grows with sessions × context.
     @Published var concurrentSessions: Int { didSet { d.set(concurrentSessions, forKey: "concurrentSessions") } }
     @Published var kvDiskCache: Bool { didSet { d.set(kvDiskCache, forKey: "kvDiskCache") } }
+    /// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM; the
+    /// rest stream from the GGUF on demand. Default ON with the ~15 GiB-free budget
+    /// for the selected quant.
+    @Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+    @Published var ssdStreamingCacheGB: Int {
+        didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+    }
     /// The chat's thinking level (Off / Standard / Max Think). Coding-agent CLIs set their
     /// own per-request level, so this affects only the built-in chat.
     @Published var thinkingMode: ThinkingMode { didSet { d.set(thinkingMode.rawValue, forKey: "thinkingMode") } }
@@ -83,7 +90,14 @@ final class AppState: ObservableObject {
         let stored = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:))
         selectedVariant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
         let storedQuant = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
-        selectedFlashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
+        let flashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
+        selectedFlashQuant = flashQuant
+        ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true  // default on
+        if let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int {
+            ssdStreamingCacheGB = storedGB
+        } else {
+            ssdStreamingCacheGB = Quant.for(selectedVariant, flashQuant: flashQuant).defaultStreamingCacheGB
+        }
     }
 
     func effectiveCtx(ramGiB: Double) -> Int {

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -49,6 +49,28 @@ final class AppState: ObservableObject {
     @Published var selectedModel: Model {
         didSet { d.set(selectedModel.rawValue, forKey: "selectedModel") }
     }
+    /// Compatibility shims over `selectedModel` for the DS4F wired-limit gate
+    /// (#15's WiredLimitHelpView and the Settings ctx clamp key off the variant pair).
+    var selectedVariant: Variant {
+        get { selectedModel == .v4Pro ? .pro : .flash }
+        set { selectedModel = newValue == .pro ? .v4Pro : .v4FlashQ2Q4 }
+    }
+    var selectedFlashQuant: FlashQuant {
+        get {
+            switch selectedModel.quant {
+            case .q4Imatrix: return .q4
+            case .q2Imatrix: return .q2
+            default: return .q2q4
+            }
+        }
+        set {
+            switch newValue {
+            case .q2: selectedModel = .v4FlashQ2
+            case .q4: selectedModel = .v4FlashQ4
+            case .q2q4: selectedModel = selectedModel == .v4Pro ? .v4Pro : .v4FlashQ2Q4
+            }
+        }
+    }
 
     init(defaults: UserDefaults = .standard, ramGiB: Double = systemRamGiB()) {
         self.d = defaults
@@ -114,7 +136,8 @@ final class AppState: ObservableObject {
     func effectiveCtx(ramGiB: Double) -> Int {
         ctxOverride > 0
             ? min(ctxOverride, selectedModel.ctxCeiling)
-            : defaultCtx(ramGiB: ramGiB, model: selectedModel)    }
+            : defaultCtx(ramGiB: ramGiB, model: selectedModel)
+    }
 
     /// Set the chat's thinking level. Max is unavailable below 128 GiB and otherwise needs
     /// context ≥ 393,216. Rejections leave the current mode unchanged.

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -120,7 +120,8 @@ final class AppState: ObservableObject {
     /// Flash q2 96–127, Laguna below — the only feasible model on 64 GB-class machines).
     static func migrateLegacySelection(defaults d: UserDefaults, ramGiB: Double) -> Model {
         if let v = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:)),
-            let f = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:)) {
+            let f = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
+        {
             if v == .pro { return .v4Pro }
             switch f {
             case .q2: return .v4FlashQ2

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -46,13 +46,29 @@ final class AppState: ObservableObject {
     @Published var legacyWeightsPromptDismissed: Bool {
         didSet { d.set(legacyWeightsPromptDismissed, forKey: "legacyWeightsPromptDismissed0731") }
     }
-    @Published var selectedVariant: Variant {
-        didSet { d.set(selectedVariant.rawValue, forKey: "selectedVariant") }
+    @Published var selectedModel: Model {
+        didSet { d.set(selectedModel.rawValue, forKey: "selectedModel") }
     }
-    /// User-selected V4 Flash quant (default q2-q4-imatrix). Drives the Flash download/run
-    /// filename and the auto-context calc; V4 Pro ignores it.
-    @Published var selectedFlashQuant: FlashQuant {
-        didSet { d.set(selectedFlashQuant.rawValue, forKey: "selectedFlashQuant") }
+    /// Compatibility shims over `selectedModel` (removed once the unified picker lands).
+    var selectedVariant: Variant {
+        get { selectedModel == .v4Pro ? .pro : .flash }
+        set { selectedModel = newValue == .pro ? .v4Pro : .v4FlashQ2Q4 }
+    }
+    var selectedFlashQuant: FlashQuant {
+        get {
+            switch selectedModel.quant {
+            case .q4Imatrix: return .q4
+            case .q2Imatrix: return .q2
+            default: return .q2q4
+            }
+        }
+        set {
+            switch newValue {
+            case .q2: selectedModel = .v4FlashQ2
+            case .q4: selectedModel = .v4FlashQ4
+            case .q2q4: selectedModel = selectedModel == .v4Pro ? .v4Pro : .v4FlashQ2Q4
+            }
+        }
     }
 
     init(defaults: UserDefaults = .standard, ramGiB: Double = systemRamGiB()) {
@@ -87,18 +103,32 @@ final class AppState: ObservableObject {
         highPerformanceDownload = d.bool(forKey: "highPerformanceDownload")  // default off
         launchAtLogin = SMAppService.mainApp.status == .enabled  // OS is the source of truth
         legacyWeightsPromptDismissed = d.bool(forKey: "legacyWeightsPromptDismissed0731")  // default false
-        let stored = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:))
-        let variant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
-        selectedVariant = variant
-        let storedQuant = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
-        let flashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
-        selectedFlashQuant = flashQuant
+        let storedModel = d.string(forKey: "selectedModel").flatMap(Model.init(rawValue:))
+        let model = storedModel ?? Self.migrateLegacySelection(defaults: d, ramGiB: ramGiB)
+        selectedModel = model
         ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true  // default on
         if let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int {
             ssdStreamingCacheGB = storedGB
         } else {
-            ssdStreamingCacheGB = Quant.for(variant, flashQuant: flashQuant).defaultStreamingCacheGB
+            // Fresh install: the ~15 GiB-free budget for the default DS4F quant; inert for Laguna.
+            ssdStreamingCacheGB = model.quant?.defaultStreamingCacheGB ?? Quant.q2q4Imatrix.defaultStreamingCacheGB
         }
+    }
+
+    /// First-launch model selection: the legacy selectedVariant/selectedFlashQuant keys
+    /// migrate into `selectedModel`; otherwise tier by RAM (Pro ≥512, Flash q2-q4 ≥128,
+    /// Flash q2 96–127, Laguna below — the only feasible model on 64 GB-class machines).
+    static func migrateLegacySelection(defaults d: UserDefaults, ramGiB: Double) -> Model {
+        if let v = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:)),
+            let f = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:)) {
+            if v == .pro { return .v4Pro }
+            switch f {
+            case .q2: return .v4FlashQ2
+            case .q4: return .v4FlashQ4
+            default: return .v4FlashQ2Q4
+            }
+        }
+        return ramGiB >= 512 ? .v4Pro : ramGiB >= 128 ? .v4FlashQ2Q4 : ramGiB >= 96 ? .v4FlashQ2 : .lagunaS21
     }
 
     func effectiveCtx(ramGiB: Double) -> Int {

--- a/Sources/DS4Control/AppState.swift
+++ b/Sources/DS4Control/AppState.swift
@@ -88,7 +88,8 @@ final class AppState: ObservableObject {
         launchAtLogin = SMAppService.mainApp.status == .enabled  // OS is the source of truth
         legacyWeightsPromptDismissed = d.bool(forKey: "legacyWeightsPromptDismissed0731")  // default false
         let stored = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:))
-        selectedVariant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
+        let variant = stored ?? (ramGiB >= 512 ? .pro : .flash)  // default Pro on ≥512 GiB
+        selectedVariant = variant
         let storedQuant = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:))
         let flashQuant = storedQuant ?? defaultFlashQuant(ramGiB: ramGiB)  // default q2-q4-imatrix
         selectedFlashQuant = flashQuant
@@ -96,7 +97,7 @@ final class AppState: ObservableObject {
         if let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int {
             ssdStreamingCacheGB = storedGB
         } else {
-            ssdStreamingCacheGB = Quant.for(selectedVariant, flashQuant: flashQuant).defaultStreamingCacheGB
+            ssdStreamingCacheGB = Quant.for(variant, flashQuant: flashQuant).defaultStreamingCacheGB
         }
     }
 

--- a/Sources/DS4Control/DS4ControlApp.swift
+++ b/Sources/DS4Control/DS4ControlApp.swift
@@ -21,7 +21,7 @@ struct DS4ControlApp: App {
         let service = ChatService()
         _chat = StateObject(
             wrappedValue: ChatViewModel(
-                model: app.selectedVariant.modelId,
+                model: app.selectedModel.modelId,
                 port: { [weak supervisor] in supervisor?.port ?? app.port },
                 streamProvider: { port, model, messages in
                     service.stream(port: port, model: model, messages: messages, mode: app.thinkingMode)

--- a/Sources/DS4Control/DS4ControlApp.swift
+++ b/Sources/DS4Control/DS4ControlApp.swift
@@ -62,7 +62,7 @@ struct DS4ControlApp: App {
             metrics.start()
             supervisor.resumeRunningServerIfAny(port: app.port)
             supervisor.resumeInFlightDownloadIfAny(
-                variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+                model: app.selectedModel,
                 highPerformance: app.highPerformanceDownload)
         }
     }

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -362,10 +362,23 @@ private func metalIndexerScratchBytes(variant: Variant, ctx: Int) -> Int? {
 /// one prefill workspace plus persistent backend scratch shared across sessions. Context
 /// counts regardless of the disk KV cache: disk storage checkpoints resident tensors; it
 /// does not replace them.
-func requiredWiredMB(variant: Variant, flashQuant: FlashQuant, ctx: Int, sessions: Int = 1) -> Int {
+func requiredWiredMB(
+    variant: Variant, flashQuant: FlashQuant, ctx: Int, sessions: Int = 1,
+    ssdStreamingCacheGB: Int = 0
+) -> Int {
     let quant = Quant.for(variant, flashQuant: flashQuant)
+    // SSD streaming keeps only the expert-cache budget + non-routed weights resident;
+    // the routed experts beyond the budget stream from the GGUF on demand. Charge the
+    // resident set (not the full GGUF) when a budget is in effect.
+    let residentWeightsMB: Int?
+    if ssdStreamingCacheGB > 0 {
+        let residentGiB = quant.weightsGiB - quant.routedExpertGiB + Double(ssdStreamingCacheGB)
+        residentWeightsMB = roundedUpMiB(Int(residentGiB * 1_073_741_824))
+    } else {
+        residentWeightsMB = roundedUpMiB(quant.ggufBytes)
+    }
     guard
-        let weightsMB = roundedUpMiB(quant.ggufBytes),
+        let weightsMB = residentWeightsMB,
         let sessionBytes = metalContextBytes(variant: variant, ctx: ctx),
         let sessionGraphBytes = metalSessionGraphBytes(variant: variant, ctx: ctx),
         let sharedGraphBytes = metalSharedGraphWorkspaceBytes(variant: variant, ctx: ctx),
@@ -424,7 +437,7 @@ func defaultFlashQuant(ramGiB: Double) -> FlashQuant {
 /// ceiling (`wiredLimitMB` — inject `effectiveWiredLimitMB(ramGiB:)` at the call site).
 func feasibility(
     ramGiB: Double, variant: Variant, flashQuant: FlashQuant,
-    ctx: Int, wiredLimitMB: Int, sessions: Int = 1
+    ctx: Int, wiredLimitMB: Int, sessions: Int = 1, ssdStreamingCacheGB: Int = 0
 ) -> Feasibility {
     if let reason = launchBoundsError(variant: variant, ctx: ctx, sessions: sessions) {
         return .blocked(reason: reason)
@@ -441,7 +454,8 @@ func feasibility(
         }
     }
     let required = requiredWiredMB(
-        variant: variant, flashQuant: flashQuant, ctx: ctx, sessions: sessions)
+        variant: variant, flashQuant: flashQuant, ctx: ctx, sessions: sessions,
+        ssdStreamingCacheGB: ssdStreamingCacheGB)
     if required == Int.max {
         return .blocked(
             reason:

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -425,7 +425,7 @@ func defaultCtx(ramGiB: Double, model: Model) -> Int {
     case .lagunaS21: return 50_000
     case .v4Pro: return model.ctxCeiling
     case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4:
-        return ramGiB >= 128 ? model.ctxCeiling : thinkMaxMinCtx
+        return ramGiB >= 128 ? model.ctxCeiling : 256_000  // matches #15's 256K tier
     }
 }
 
@@ -521,7 +521,8 @@ func feasibility(ramGiB: Double, model: Model) -> Feasibility {
     case .lagunaS21:
         guard ramGiB >= 64 else {
             return .blocked(
-                reason: "Laguna S 2.1 needs ≥ 64 GiB unified memory — its ~45 GiB weights plus the OS reserve don't fit below that."
+                reason:
+                    "Laguna S 2.1 needs ≥ 64 GiB unified memory — its ~45 GiB weights plus the OS reserve don't fit below that."
             )
         }
         return .standard

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -493,11 +493,15 @@ func feasibility(
 /// below 64 GiB the weights + 8 GiB OS reserve don't fit.
 /// Config-specific feasibility for the unified picker: DS4F routes through the full
 /// Metal wired-limit gate; Laguna (no Metal shape yet) is gated by its RAM floor.
-func feasibility(ramGiB: Double, model: Model, ctx: Int, wiredLimitMB: Int, sessions: Int = 1) -> Feasibility {
+func feasibility(
+    ramGiB: Double, model: Model, ctx: Int, wiredLimitMB: Int, sessions: Int = 1,
+    ssdStreamingCacheGB: Int = 0
+) -> Feasibility {
     if let v = model.variant, let f = model.flashQuant {
         return feasibility(
             ramGiB: ramGiB, variant: v, flashQuant: f, ctx: ctx,
-            wiredLimitMB: wiredLimitMB, sessions: sessions)
+            wiredLimitMB: wiredLimitMB, sessions: sessions,
+            ssdStreamingCacheGB: ssdStreamingCacheGB)
     }
     return feasibility(ramGiB: ramGiB, model: model)
 }

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -418,6 +418,18 @@ func defaultCtx(ramGiB: Double, variant: Variant, flashQuant: FlashQuant) -> Int
 }
 
 /// Whether a Flash quant's default launch fits while preserving the OS reserve.
+/// Default context keyed on the runnable model. Laguna defaults to 50,000 (SWA-capped
+/// KV is cheap; scratch is bounded by --prefill-chunk 4096); DS4F keeps its tiers.
+func defaultCtx(ramGiB: Double, model: Model) -> Int {
+    switch model {
+    case .lagunaS21: return 50_000
+    case .v4Pro: return model.ctxCeiling
+    case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4:
+        return ramGiB >= 128 ? model.ctxCeiling : thinkMaxMinCtx
+    }
+}
+
+/// Whether a Flash quant's resident weights fit this machine (weights + OS reserve ≤ RAM).
 /// Drives which options the Settings quant picker offers.
 func flashQuantFits(_ q: FlashQuant, ramGiB: Double) -> Bool {
     let ctx = defaultCtx(ramGiB: ramGiB, variant: .flash, flashQuant: q)
@@ -473,4 +485,34 @@ func feasibility(
         return .wiredLimitTooLow(requiredMB: required, advisoryMB: usableMB)
     }
     return .standard
+}
+
+/// Feasibility gate keyed on the runnable model. Laguna S 2.1 (q2-q3, 44.95 GiB
+/// weights) targets 64 GB-class machines: ≥96 GiB is comfortable; 64–95 GiB fits
+/// only with the Metal wired limit raised (default ~0.67×RAM ≈ 43 GiB < weights);
+/// below 64 GiB the weights + 8 GiB OS reserve don't fit.
+/// RAM-tier feasibility for the model picker: which models can run on this machine at
+/// all. The config-specific Metal wired-limit gate lives in `feasibility(variant:…ctx:wiredLimitMB:sessions:)`
+/// and is applied at Start time by the supervisor (and by the popup's Start-anyway flow).
+func feasibility(ramGiB: Double, model: Model) -> Feasibility {
+    switch model {
+    case .v4Pro:
+        guard ramGiB >= 512 else { return .blocked(reason: "V4 Pro needs ≥ 512 GiB unified memory.") }
+        return .standard
+    case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4:
+        guard ramGiB >= 96 else {
+            return .blocked(
+                reason:
+                    "V4 Flash needs ≥ 96 GiB unified memory. Below that, the ~\(Int(model.weightsGiB)) GiB model plus its KV cache exceed RAM, so it can't run."
+            )
+        }
+        return .standard
+    case .lagunaS21:
+        guard ramGiB >= 64 else {
+            return .blocked(
+                reason: "Laguna S 2.1 needs ≥ 64 GiB unified memory — its ~45 GiB weights plus the OS reserve don't fit below that."
+            )
+        }
+        return .standard
+    }
 }

--- a/Sources/DS4Control/Model/Feasibility.swift
+++ b/Sources/DS4Control/Model/Feasibility.swift
@@ -491,6 +491,17 @@ func feasibility(
 /// weights) targets 64 GB-class machines: ≥96 GiB is comfortable; 64–95 GiB fits
 /// only with the Metal wired limit raised (default ~0.67×RAM ≈ 43 GiB < weights);
 /// below 64 GiB the weights + 8 GiB OS reserve don't fit.
+/// Config-specific feasibility for the unified picker: DS4F routes through the full
+/// Metal wired-limit gate; Laguna (no Metal shape yet) is gated by its RAM floor.
+func feasibility(ramGiB: Double, model: Model, ctx: Int, wiredLimitMB: Int, sessions: Int = 1) -> Feasibility {
+    if let v = model.variant, let f = model.flashQuant {
+        return feasibility(
+            ramGiB: ramGiB, variant: v, flashQuant: f, ctx: ctx,
+            wiredLimitMB: wiredLimitMB, sessions: sessions)
+    }
+    return feasibility(ramGiB: ramGiB, model: model)
+}
+
 /// RAM-tier feasibility for the model picker: which models can run on this machine at
 /// all. The config-specific Metal wired-limit gate lives in `feasibility(variant:…ctx:wiredLimitMB:sessions:)`
 /// and is applied at Start time by the supervisor (and by the popup's Start-anyway flow).

--- a/Sources/DS4Control/Model/Model.swift
+++ b/Sources/DS4Control/Model/Model.swift
@@ -13,6 +13,36 @@ enum Model: String, CaseIterable, Identifiable, Codable {
 
     var id: String { rawValue }
 
+    /// Map a legacy (variant, flashQuant) pair to a `Model` (used by the transitional
+    /// start/restart wrappers and cleanup; removed once the unified picker lands).
+    static func from(variant: Variant, flashQuant: FlashQuant) -> Model {
+        if variant == .pro { return .v4Pro }
+        switch flashQuant {
+        case .q2: return .v4FlashQ2
+        case .q4: return .v4FlashQ4
+        default: return .v4FlashQ2Q4
+        }
+    }
+
+    /// The DS4F variant this model maps to (nil for Laguna). Used to route the
+    /// DS4F-only Metal wired-limit gate in the supervisor launch path.
+    var variant: Variant? {
+        switch self {
+        case .v4Pro: return .pro
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return .flash
+        case .lagunaS21: return nil
+        }
+    }
+    /// The DS4F Flash quant this model maps to (nil for Pro/Laguna).
+    var flashQuant: FlashQuant? {
+        switch quant {
+        case .q4Imatrix: return .q4
+        case .q2Imatrix: return .q2
+        case .q2q4Imatrix: return .q2q4
+        default: return nil
+        }
+    }
+
     /// The DS4F quant this model maps to (nil for Laguna — it has no DS4F quant).
     var quant: Quant? {
         switch self {

--- a/Sources/DS4Control/Model/Model.swift
+++ b/Sources/DS4Control/Model/Model.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The runnable models DS4 Control can download and serve. A `Model` fully
+/// determines identity, download metadata, feasibility, and per-model capability
+/// (SSD streaming, thinking modes). DS4F variants map to the existing `Quant`
+/// table; Laguna S 2.1 is its own row (facts measured from the GGUF on disk).
+enum Model: String, CaseIterable, Identifiable, Codable {
+    case v4Pro
+    case v4FlashQ2
+    case v4FlashQ2Q4
+    case v4FlashQ4
+    case lagunaS21
+
+    var id: String { rawValue }
+
+    /// The DS4F quant this model maps to (nil for Laguna — it has no DS4F quant).
+    var quant: Quant? {
+        switch self {
+        case .v4Pro: return .proImatrix
+        case .v4FlashQ2: return .q2Imatrix
+        case .v4FlashQ2Q4: return .q2q4Imatrix
+        case .v4FlashQ4: return .q4Imatrix
+        case .lagunaS21: return nil
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .v4Pro: return "V4 Pro"
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return "V4 Flash"
+        case .lagunaS21: return "Laguna S 2.1"
+        }
+    }
+
+    /// Picker label: display name + resident size, e.g. "V4 Flash · ~91 GiB".
+    var label: String { "\(displayName) · ~\(Int(weightsGiB.rounded())) GiB" }
+
+    var modelId: String {
+        switch self {
+        case .v4Pro: return "deepseek-v4-pro"
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return "deepseek-v4-flash"
+        case .lagunaS21: return "laguna-s-2.1"
+        }
+    }
+
+    /// Transformer layers (DS4 shape): Pro 61, Flash 43, Laguna S 48.
+    var layers: Int {
+        switch self {
+        case .v4Pro: return 61
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return 43
+        case .lagunaS21: return 48
+        }
+    }
+
+    /// Context ceiling: DS4F 1M; Laguna 262,144 (GGUF `laguna.context_length`).
+    var ctxCeiling: Int {
+        switch self {
+        case .lagunaS21: return 262_144
+        default: return 1_000_000
+        }
+    }
+
+    /// Approx resident weights, GiB (mmap'd GGUF ≈ file size; Laguna measured).
+    var weightsGiB: Double {
+        quant?.weightsGiB ?? 44.95
+    }
+
+    /// Routed-expert bytes for the SSD-streaming budget table; nil for Laguna
+    /// (SSD streaming not supported there).
+    var routedExpertGiB: Double? { quant?.routedExpertGiB }
+
+    var supportsSSDStreaming: Bool { quant != nil }
+    /// v1: thinking-mode picker is DS4F-only (Laguna uses native interleaved reasoning).
+    var supportsThinkingModes: Bool { quant != nil }
+
+    var downloadRepo: String {
+        switch self {
+        case .lagunaS21: return "antirez/Laguna-S-2.1-GGUF"
+        default: return "antirez/deepseek-v4-gguf"
+        }
+    }
+    var downloadRevision: String { "main" }
+    var ggufFilename: String {
+        quant?.ggufFilename ?? "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf"
+    }
+
+    /// Family launch tweak: Laguna bounds graph scratch on 64 GB-class machines
+    /// (measured: prefill 16384 → ~5.9 GiB scratch; 4096 → ~1.5 GiB).
+    var defaultPrefillChunk: Int? { self == .lagunaS21 ? 4096 : nil }
+}

--- a/Sources/DS4Control/Model/Model.swift
+++ b/Sources/DS4Control/Model/Model.swift
@@ -102,6 +102,8 @@ enum Model: String, CaseIterable, Identifiable, Codable {
     var supportsSSDStreaming: Bool { quant != nil }
     /// v1: thinking-mode picker is DS4F-only (Laguna uses native interleaved reasoning).
     var supportsThinkingModes: Bool { quant != nil }
+    /// ds4 gates Laguna to the "standard local graph path only" — no `--power` cap.
+    var supportsPowerCap: Bool { quant != nil }
 
     var downloadRepo: String {
         switch self {
@@ -113,8 +115,4 @@ enum Model: String, CaseIterable, Identifiable, Codable {
     var ggufFilename: String {
         quant?.ggufFilename ?? "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf"
     }
-
-    /// Family launch tweak: Laguna bounds graph scratch on 64 GB-class machines
-    /// (measured: prefill 16384 → ~5.9 GiB scratch; 4096 → ~1.5 GiB).
-    var defaultPrefillChunk: Int? { self == .lagunaS21 ? 4096 : nil }
 }

--- a/Sources/DS4Control/Model/Variant.swift
+++ b/Sources/DS4Control/Model/Variant.swift
@@ -71,6 +71,25 @@ enum Quant {
         }
     }
 
+    /// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to disk.
+    /// q2-q4 measured from the 0731 GGUF metadata (ffn gate/up/down expert tensors);
+    /// the others are estimated as total weights minus ~8 GiB non-routed
+    /// (attention, embeddings, shared FFN, norms).
+    var routedExpertGiB: Double {
+        switch self {
+        case .proImatrix: return 424
+        case .q4Imatrix: return 145
+        case .q2Imatrix: return 73
+        case .q2q4Imatrix: return 82.69
+        }
+    }
+
+    /// Default SSD-streaming expert-cache budget (GiB) for this quant: keeps all but
+    /// ~15 GiB of routed experts resident; the rest stream from the GGUF on demand.
+    /// Truncates (82.69 − 15 → 67). Floor 16 so a degenerate tiny cache can never be
+    /// configured accidentally.
+    var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }
+
     /// Pre-0731 ("preview") Flash GGUF filenames this app used to download. Referenced only
     /// by the one-time migration cleanup; Pro never had a preview build.
     static let legacyPreviewFilenames = [

--- a/Sources/DS4Control/Services/AgentLauncher.swift
+++ b/Sources/DS4Control/Services/AgentLauncher.swift
@@ -6,12 +6,12 @@ import Foundation
 /// (`PI_CODING_AGENT_DIR`). Port and context window are baked in at click time.
 enum AgentLauncher {
     /// Model ids ds4-server exposes; used to prefer the server's reported model.
-    static let knownModelIds = ["deepseek-v4-pro", "deepseek-v4-flash"]
+    static let knownModelIds = ["deepseek-v4-pro", "deepseek-v4-flash", "laguna-s-2.1"]
 
     /// The running model id (e.g. "deepseek-v4-flash"). Prefers the server's reported
-    /// `activeModel` when it is a known id; otherwise the selected variant's id (covers the
+    /// `activeModel` when it is a known id; otherwise the selected model's id (covers the
     /// orphan-attach case where `activeModel` is a server display name).
-    static func modelId(for activeModel: String?, fallback: Variant) -> String {
+    static func modelId(for activeModel: String?, fallback: Model) -> String {
         activeModel.flatMap { knownModelIds.contains($0) ? $0 : nil } ?? fallback.modelId
     }
 
@@ -62,6 +62,16 @@ enum AgentLauncher {
                       "input": ["text"],
                       "contextWindow": \(contextWindow),
                       "maxTokens": 393216,
+                      "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+                    },
+                    {
+                      "id": "laguna-s-2.1",
+                      "name": "Laguna S 2.1 (ds4.c local)",
+                      "reasoning": true,
+                      "thinkingLevelMap": \(levelMap),
+                      "input": ["text"],
+                      "contextWindow": \(contextWindow),
+                      "maxTokens": 262144,
                       "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
                     }
                   ]

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -563,12 +563,15 @@ final class SupervisorService: ObservableObject {
     /// stuck/stalled or errored progress bar. The native downloader cancels through the cancelled
     /// task; `download` re-resumes from the on-disk bitmap.
     func retryDownload(variant: Variant, flashQuant: FlashQuant, highPerformance: Bool = false) {
+        retryDownload(model: Model.from(variant: variant, flashQuant: flashQuant), highPerformance: highPerformance)
+    }
+    func retryDownload(model: Model, highPerformance: Bool = false) {
         downloadTask?.cancel()
         downloadTask = nil
         lastDownloadSample = nil
         download = nil
         state = .idle
-        download(variant: variant, flashQuant: flashQuant, highPerformance: highPerformance)
+        download(model: model, highPerformance: highPerformance)
     }
 
     /// Cancel an in-progress download and return to idle without restarting. Bumping the generation
@@ -598,17 +601,20 @@ final class SupervisorService: ObservableObject {
     /// so this is just a normal `download()`. `highPerformance` (the persisted setting) is threaded
     /// through so the resumed download uses the user's chosen worker count.
     func resumeInFlightDownloadIfAny(variant: Variant, flashQuant: FlashQuant, highPerformance: Bool = false) {
+        resumeInFlightDownloadIfAny(
+            model: Model.from(variant: variant, flashQuant: flashQuant), highPerformance: highPerformance)
+    }
+    func resumeInFlightDownloadIfAny(model: Model, highPerformance: Bool = false) {
         guard state == .idle else { return }
         let base = ggufBaseDir()
-        let q = Quant.for(variant, flashQuant: flashQuant)
         // Already fully downloaded → nothing to resume.
-        if FileManager.default.fileExists(atPath: base.appendingPathComponent(q.ggufFilename).path) { return }
+        if FileManager.default.fileExists(atPath: base.appendingPathComponent(model.ggufFilename).path) { return }
         // Resume when the bitmap sidecar records durable bytes (parallel partial), or a legacy
         // contiguous `.part`/hf `.incomplete` has bytes on disk.
-        let resumable = resumableBytes(ggufDir: base, filename: q.ggufFilename) > 0
-        let legacy = downloadedBytes(ggufDir: base, filename: q.ggufFilename) > 0
+        let resumable = resumableBytes(ggufDir: base, filename: model.ggufFilename) > 0
+        let legacy = downloadedBytes(ggufDir: base, filename: model.ggufFilename) > 0
         guard resumable || legacy else { return }
-        download(variant: variant, flashQuant: flashQuant, highPerformance: highPerformance)
+        download(model: model, highPerformance: highPerformance)
     }
 
     /// True when the model's gguf exists on disk.

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -122,8 +122,11 @@ final class SupervisorService: ObservableObject {
         }
         return ggufBaseOverride ?? ds4Dir.appendingPathComponent("gguf")
     }
+    private func ggufURL(for model: Model) -> URL {
+        ggufBaseDir().appendingPathComponent(model.ggufFilename)
+    }
     private func ggufURL(for variant: Variant, flashQuant: FlashQuant) -> URL {
-        ggufBaseDir().appendingPathComponent(Quant.for(variant, flashQuant: flashQuant).ggufFilename)
+        ggufURL(for: Model.from(variant: variant, flashQuant: flashQuant))
     }
     private func validateDs4Dir() -> ServerError? {
         for f in ["ds4-server", "download_model.sh"] {
@@ -162,30 +165,52 @@ final class SupervisorService: ObservableObject {
         ssdStreaming: Bool = false,
         ssdStreamingCacheGB: Int = 0
     ) {
+        start(
+            model: Model.from(variant: variant, flashQuant: flashQuant), ctx: ctx, host: host,
+            port: port, power: power, sessions: sessions, kvDiskDir: kvDiskDir,
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: ssdStreaming, ssdStreamingCacheGB: ssdStreamingCacheGB)
+    }
+
+    func start(
+        model: Model,
+        ctx: Int,
+        host: String,
+        port: Int,
+        power: Int?,
+        sessions: Int = 1,
+        kvDiskDir: URL? = nil,
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
+    ) {
         guard state == .idle || isErrorState else { emitBadState("start"); return }
         if let e = validateDs4Dir() { state = .error(e); return }
-        if let reason = launchBoundsError(variant: variant, ctx: ctx, sessions: sessions) {
-            state = .error(.configurationBlocked(reason: reason))
-            return
+        if let v = model.variant, let f = model.flashQuant {
+            if let reason = launchBoundsError(variant: v, ctx: ctx, sessions: sessions) {
+                state = .error(.configurationBlocked(reason: reason))
+                return
+            }
+            // Defense-in-depth for the popup gate (DS4F): refuse configs whose GPU-wired
+            // working set exceeds the effective Metal wired limit. The confirmed
+            // "Start anyway" path passes the override. Laguna has no variant, so it is
+            // gated only by its RAM floor in feasibility(model:).
+            switch wiredLimitGate(v, f, ctx, sessions) {
+            case let .blocked(reason):
+                state = .error(.configurationBlocked(reason: reason))
+                return
+            case let .wiredLimitTooLow(required, advisory) where !overrideWiredLimitGate:
+                state = .error(.wiredLimitTooLow(requiredMB: required, advisoryMB: advisory))
+                return
+            case .standard, .wiredLimitTooLow:
+                break
+            }
         }
-        // Defense-in-depth for the popup gate: refuse configs whose GPU-wired working set
-        // exceeds the effective Metal wired limit (starting anyway pages the model and
-        // hangs the machine). The UI's confirmed "Start anyway" passes the override.
-        switch wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0) {
-        case let .blocked(reason):
-            state = .error(.configurationBlocked(reason: reason))
-            return
-        case let .wiredLimitTooLow(required, advisory) where !overrideWiredLimitGate:
-            state = .error(.wiredLimitTooLow(requiredMB: required, advisoryMB: advisory))
-            return
-        case .standard, .wiredLimitTooLow:
-            break
-        }
-        let gguf = ggufURL(for: variant, flashQuant: flashQuant)
+        let gguf = ggufURL(for: model)
         guard FileManager.default.fileExists(atPath: gguf.path) else {
             state = .error(.modelMissing(filename: gguf.lastPathComponent)); return
         }
-        self.port = port; self.ctx = ctx; self.activeModel = variant.modelId
+        self.port = port; self.ctx = ctx; self.activeModel = model.modelId
         stderrTail = []; expectingExit = false; serverAttached = false
         var args = [
             "-m", gguf.path,
@@ -194,14 +219,18 @@ final class SupervisorService: ObservableObject {
             "--port", "\(port)",
             "--metal",
         ]
-        if ssdStreaming {
-            // SSD-backed expert streaming: only `ssdStreamingCacheGB` of routed experts
-            // stay resident; the rest load from the GGUF on cache miss. 0 omits the
-            // budget so ds4 picks its automatic cache.
+        if model.supportsSSDStreaming && ssdStreaming {
+            // SSD-backed expert streaming (DS4F only). ds4 hard-refuses this flag for
+            // Laguna S 2.1, so it is never passed for that model.
             args += ["--ssd-streaming"]
             if ssdStreamingCacheGB > 0 {
                 args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
             }
+        }
+        if let chunk = model.defaultPrefillChunk {
+            // Bounds the graph scratch on 64 GB-class machines (measured: ~1.5 GiB at
+            // 4096 vs ~5.9 GiB at Laguna's default 16384).
+            args += ["--prefill-chunk", "\(chunk)"]
         }
         if let power { args += ["--power", "\(power)"] }
         // >1 preallocates N resident KV sessions so that many chats/agents generate at once.
@@ -319,29 +348,52 @@ final class SupervisorService: ObservableObject {
         ssdStreaming: Bool = false,
         ssdStreamingCacheGB: Int = 0
     ) -> RestartResult {
+        restart(
+            model: Model.from(variant: variant, flashQuant: flashQuant), ctx: ctx, host: host,
+            port: port, power: power, sessions: sessions, kvDiskDir: kvDiskDir,
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: ssdStreaming, ssdStreamingCacheGB: ssdStreamingCacheGB)
+    }
+
+    @discardableResult
+    func restart(
+        model: Model,
+        ctx: Int,
+        host: String,
+        port: Int,
+        power: Int?,
+        sessions: Int = 1,
+        kvDiskDir: URL? = nil,
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
+    ) -> RestartResult {
         guard state == .ready || state == .starting else {
             emitBadState("restart")
             return .ignored
         }
-        if let reason = launchBoundsError(variant: variant, ctx: ctx, sessions: sessions) {
-            recentLog.append("ignored 'restart': \(reason)")
-            return .rejected(.blocked(reason: reason))
-        }
-        let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0)
-        switch feasibility {
-        case let .blocked(reason):
-            recentLog.append("ignored 'restart': \(reason)")
-            return .rejected(feasibility)
-        case .wiredLimitTooLow where !overrideWiredLimitGate:
-            recentLog.append("ignored 'restart': Metal wired limit below the new config's working set")
-            return .rejected(feasibility)
-        case .standard, .wiredLimitTooLow:
-            break
+        if let v = model.variant, let f = model.flashQuant {
+            if let reason = launchBoundsError(variant: v, ctx: ctx, sessions: sessions) {
+                recentLog.append("ignored 'restart': \(reason)")
+                return .rejected(.blocked(reason: reason))
+            }
+            // Gate BEFORE stopping: a refused restart keeps the healthy running server.
+            let feasibility = wiredLimitGate(v, f, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0)
+            switch feasibility {
+            case let .blocked(reason):
+                recentLog.append("ignored 'restart': \(reason)")
+                return .rejected(feasibility)
+            case .wiredLimitTooLow where !overrideWiredLimitGate:
+                recentLog.append("ignored 'restart': Metal wired limit below the new config's working set")
+                return .rejected(feasibility)
+            case .standard, .wiredLimitTooLow:
+                break
+            }
         }
         let relaunch: () -> Void = { [weak self] in
             guard let self else { return }
             self.start(
-                variant: variant, flashQuant: flashQuant, ctx: ctx, host: host, port: port, power: power,
+                model: model, ctx: ctx, host: host, port: port, power: power,
                 sessions: sessions, kvDiskDir: kvDiskDir, overrideWiredLimitGate: overrideWiredLimitGate,
                 ssdStreaming: ssdStreaming, ssdStreamingCacheGB: ssdStreamingCacheGB)
         }
@@ -349,15 +401,12 @@ final class SupervisorService: ObservableObject {
         if state == .idle {
             relaunch()  // stopped synchronously (the runner exited inline)
         } else {
-            pendingRestart = relaunch  // deferred until stop drains (handleExit, or the attached-pid poll)
+            pendingRestart = relaunch  // deferred until stop drains
         }
         return .accepted
     }
 
-    /// On launch, if a ds4-server is already serving on `port` (orphaned from a prior
-    /// session, model still loaded), attach to it as `.ready` instead of spawning a
-    /// new one — avoids a port conflict and a second multi-hundred-GB load.
-    func resumeRunningServerIfAny(port: Int) {
+  func resumeRunningServerIfAny(port: Int) {
         guard state == .idle else { return }
         adoptHealthyServerIfPresent(port: port)
     }

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -196,7 +196,7 @@ final class SupervisorService: ObservableObject {
             // working set exceeds the effective Metal wired limit. The confirmed
             // "Start anyway" path passes the override. Laguna has no variant, so it is
             // gated only by its RAM floor in feasibility(model:).
-            switch wiredLimitGate(v, f, ctx, sessions) {
+            switch wiredLimitGate(v, f, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0) {
             case let .blocked(reason):
                 state = .error(.configurationBlocked(reason: reason))
                 return
@@ -402,7 +402,7 @@ final class SupervisorService: ObservableObject {
         return .accepted
     }
 
-  func resumeRunningServerIfAny(port: Int) {
+    func resumeRunningServerIfAny(port: Int) {
         guard state == .idle else { return }
         adoptHealthyServerIfPresent(port: port)
     }

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -57,10 +57,10 @@ final class SupervisorService: ObservableObject {
 
     /// The pluggable file fetch — defaults to the native parallel `HFDownloader`. Tests inject a fake
     /// that simulates progress/completion/failure without touching the network. `highPerformance`
-    /// selects the worker count (8 vs 64).
+    /// selects the worker count (8 vs 64). The model supplies the repo/revision/filename.
     typealias FetchFile =
         @Sendable (
-            _ file: String, _ destDir: URL, _ token: String?, _ highPerformance: Bool,
+            _ model: Model, _ destDir: URL, _ token: String?, _ highPerformance: Bool,
             _ onProgress: @escaping @Sendable (Int64, Int64) -> Void
         ) async throws -> Void
     private let fetchFile: FetchFile
@@ -91,9 +91,10 @@ final class SupervisorService: ObservableObject {
         self.downloadRunner = downloadRunner ?? RealProcessRunner()
         self.wiredLimitGate = wiredLimitGate ?? Self.defaultWiredLimitGate
         self.fetchFile =
-            fetchFile ?? { file, dir, token, highPerformance, prog in
-                try await HFDownloader(repo: SupervisorService.ggufRepo).download(
-                    file: file, into: dir, token: token, highPerformance: highPerformance, onProgress: prog)
+            fetchFile ?? { model, dir, token, highPerformance, prog in
+                try await HFDownloader(repo: model.downloadRepo, revision: model.downloadRevision).download(
+                    file: model.ggufFilename, into: dir, token: token, highPerformance: highPerformance,
+                    onProgress: prog)
             }
     }
 
@@ -463,16 +464,18 @@ final class SupervisorService: ObservableObject {
     private var downloadGeneration = 0
     /// The native HF download in flight (nil when idle); cancelled by cancelDownload()/retry.
     private var downloadTask: Task<Void, Never>?
-    /// HuggingFace repo hosting the DS4 GGUF weights (single source for the resolve URL).
-    private static let ggufRepo = "antirez/deepseek-v4-gguf"
 
     func download(variant: Variant, flashQuant: FlashQuant, highPerformance: Bool = false) {
+        download(model: Model.from(variant: variant, flashQuant: flashQuant), highPerformance: highPerformance)
+    }
+
+    func download(model: Model, highPerformance: Bool = false) {
         guard state == .idle || isErrorState else { emitBadState("download"); return }
         if let e = validateDs4Dir() { state = .error(e); return }
-        let q = Quant.for(variant, flashQuant: flashQuant)
         let baseDir = ggufBaseDir()
-        let expectedBytes = Int64(q.ggufBytes)
-        download = DownloadProgress(pct: 0, file: q.ggufFilename, receivedBytes: 0, totalBytes: expectedBytes)
+        // #15's exact GGUF bytes for DS4F; the measured 44.95 GiB for Laguna.
+        let expectedBytes = Int64(model.quant?.ggufBytes ?? Int(model.weightsGiB * 1_073_741_824))
+        download = DownloadProgress(pct: 0, file: model.ggufFilename, receivedBytes: 0, totalBytes: expectedBytes)
         state = .downloading
         lastDownloadSample = nil
         downloadGeneration += 1
@@ -481,7 +484,7 @@ final class SupervisorService: ObservableObject {
             env: ProcessInfo.processInfo.environment,
             cacheFile: FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".cache/huggingface/token"))
-        let filename = q.ggufFilename
+        let filename = model.ggufFilename
         downloadProcessLive = true
         // Native parallel Swift download: N workers each GET …/resolve/main/<file> with a closed
         // HTTP Range straight to their offset in `<file>.part`, re-resolving each chunk so the signed
@@ -492,7 +495,7 @@ final class SupervisorService: ObservableObject {
         downloadTask?.cancel()
         downloadTask = Task { [weak self] in
             do {
-                try await fetch(filename, baseDir, token, highPerformance) { received, total in
+                try await fetch(model, baseDir, token, highPerformance) { received, total in
                     Self.onMain {
                         self?.updateDownloadProgress(gen: gen, file: filename, received: received, total: total)
                     }
@@ -608,25 +611,30 @@ final class SupervisorService: ObservableObject {
         download(variant: variant, flashQuant: flashQuant, highPerformance: highPerformance)
     }
 
-    /// True when the selected variant's gguf exists on disk.
+    /// True when the model's gguf exists on disk.
+    func isDownloaded(_ model: Model) -> Bool {
+        FileManager.default.fileExists(atPath: ggufURL(for: model).path)
+    }
     func isDownloaded(_ variant: Variant, flashQuant: FlashQuant) -> Bool {
-        FileManager.default.fileExists(atPath: ggufURL(for: variant, flashQuant: flashQuant).path)
+        isDownloaded(Model.from(variant: variant, flashQuant: flashQuant))
     }
 
-    // MARK: - Flash quant store (Settings: download markers + cleanup)
+    // MARK: - Model store (Settings: download markers + cleanup)
     func flashQuantURL(_ q: FlashQuant) -> URL {
         ggufBaseDir().appendingPathComponent(q.quant.ggufFilename)
     }
     func isFlashQuantDownloaded(_ q: FlashQuant) -> Bool {
         FileManager.default.fileExists(atPath: flashQuantURL(q).path)
     }
-    /// Delete on-disk Flash quant ggufs other than `keep`. V4 Pro is untouched by construction
-    /// (the loop only iterates `FlashQuant`). Gate the call site to idle/error so a loaded or
-    /// downloading model is never removed. Returns the removed filenames.
+    /// Delete on-disk Flash quant ggufs other than the kept model's. V4 Pro is untouched by
+    /// construction (the loop only iterates `FlashQuant`) and the Laguna file is never touched
+    /// (it isn't a FlashQuant). Returns the removed filenames. Gate the call site to idle/error
+    /// so a loaded or downloading model is never removed.
     @discardableResult
-    func cleanupUnusedFlashQuants(keep: FlashQuant) -> [String] {
+    func cleanupUnusedModels(keep: Model) -> [String] {
+        guard let keepQuant = keep.quant else { return [] }  // Laguna: single model per family
         var removed: [String] = []
-        for q in FlashQuant.allCases where q != keep {
+        for q in FlashQuant.allCases where q.quant != keepQuant {
             let url = flashQuantURL(q)
             if FileManager.default.fileExists(atPath: url.path) {
                 try? FileManager.default.removeItem(at: url)
@@ -635,6 +643,9 @@ final class SupervisorService: ObservableObject {
         }
         ggufStoreVersion += 1
         return removed
+    }
+    func cleanupUnusedFlashQuants(keep: FlashQuant) -> [String] {
+        cleanupUnusedModels(keep: Model.from(variant: .flash, flashQuant: keep))
     }
 
     // MARK: - Legacy preview weights (pre-0731)

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -156,7 +156,9 @@ final class SupervisorService: ObservableObject {
         power: Int?,
         sessions: Int = 1,
         kvDiskDir: URL? = nil,
-        overrideWiredLimitGate: Bool = false
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
     ) {
         guard state == .idle || isErrorState else { emitBadState("start"); return }
         if let e = validateDs4Dir() { state = .error(e); return }
@@ -190,6 +192,15 @@ final class SupervisorService: ObservableObject {
             "--port", "\(port)",
             "--metal",
         ]
+        if ssdStreaming {
+            // SSD-backed expert streaming: only `ssdStreamingCacheGB` of routed experts
+            // stay resident; the rest load from the GGUF on cache miss. 0 omits the
+            // budget so ds4 picks its automatic cache.
+            args += ["--ssd-streaming"]
+            if ssdStreamingCacheGB > 0 {
+                args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+            }
+        }
         if let power { args += ["--power", "\(power)"] }
         // >1 preallocates N resident KV sessions so that many chats/agents generate at once.
         // 1 must omit the flag: ds4 treats even `--batched-session 1` as batched mode (MTP off).
@@ -302,7 +313,9 @@ final class SupervisorService: ObservableObject {
         power: Int?,
         sessions: Int = 1,
         kvDiskDir: URL? = nil,
-        overrideWiredLimitGate: Bool = false
+        overrideWiredLimitGate: Bool = false,
+        ssdStreaming: Bool = false,
+        ssdStreamingCacheGB: Int = 0
     ) -> RestartResult {
         guard state == .ready || state == .starting else {
             emitBadState("restart")
@@ -312,8 +325,6 @@ final class SupervisorService: ObservableObject {
             recentLog.append("ignored 'restart': \(reason)")
             return .rejected(.blocked(reason: reason))
         }
-        // Gate BEFORE stopping: a refused restart keeps the healthy running server instead
-        // of tearing it down into an error state.
         let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions)
         switch feasibility {
         case let .blocked(reason):
@@ -329,7 +340,8 @@ final class SupervisorService: ObservableObject {
             guard let self else { return }
             self.start(
                 variant: variant, flashQuant: flashQuant, ctx: ctx, host: host, port: port, power: power,
-                sessions: sessions, kvDiskDir: kvDiskDir, overrideWiredLimitGate: overrideWiredLimitGate)
+                sessions: sessions, kvDiskDir: kvDiskDir, overrideWiredLimitGate: overrideWiredLimitGate,
+                ssdStreaming: ssdStreaming, ssdStreamingCacheGB: ssdStreamingCacheGB)
         }
         stop()
         if state == .idle {

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -68,12 +68,14 @@ final class SupervisorService: ObservableObject {
     /// Returns the launch config's feasibility. Injectable so tests don't depend on the
     /// host's RAM/sysctl state (CI runners are far smaller than any supported machine).
     typealias WiredLimitGate =
-        (_ variant: Variant, _ flashQuant: FlashQuant, _ ctx: Int, _ sessions: Int) -> Feasibility
-    static let defaultWiredLimitGate: WiredLimitGate = { variant, flashQuant, ctx, sessions in
+        (_ variant: Variant, _ flashQuant: FlashQuant, _ ctx: Int, _ sessions: Int, _ ssdStreamingCacheGB: Int) ->
+        Feasibility
+    static let defaultWiredLimitGate: WiredLimitGate = { variant, flashQuant, ctx, sessions, ssdStreamingCacheGB in
         let ram = systemRamGiB()
         return feasibility(
             ramGiB: ram, variant: variant, flashQuant: flashQuant, ctx: ctx,
-            wiredLimitMB: effectiveWiredLimitMB(ramGiB: ram), sessions: sessions)
+            wiredLimitMB: effectiveWiredLimitMB(ramGiB: ram), sessions: sessions,
+            ssdStreamingCacheGB: ssdStreamingCacheGB)
     }
     private let wiredLimitGate: WiredLimitGate
 
@@ -169,7 +171,7 @@ final class SupervisorService: ObservableObject {
         // Defense-in-depth for the popup gate: refuse configs whose GPU-wired working set
         // exceeds the effective Metal wired limit (starting anyway pages the model and
         // hangs the machine). The UI's confirmed "Start anyway" passes the override.
-        switch wiredLimitGate(variant, flashQuant, ctx, sessions) {
+        switch wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0) {
         case let .blocked(reason):
             state = .error(.configurationBlocked(reason: reason))
             return
@@ -325,7 +327,7 @@ final class SupervisorService: ObservableObject {
             recentLog.append("ignored 'restart': \(reason)")
             return .rejected(.blocked(reason: reason))
         }
-        let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions)
+        let feasibility = wiredLimitGate(variant, flashQuant, ctx, sessions, ssdStreaming ? ssdStreamingCacheGB : 0)
         switch feasibility {
         case let .blocked(reason):
             recentLog.append("ignored 'restart': \(reason)")

--- a/Sources/DS4Control/Services/SupervisorService.swift
+++ b/Sources/DS4Control/Services/SupervisorService.swift
@@ -228,12 +228,7 @@ final class SupervisorService: ObservableObject {
                 args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
             }
         }
-        if let chunk = model.defaultPrefillChunk {
-            // Bounds the graph scratch on 64 GB-class machines (measured: ~1.5 GiB at
-            // 4096 vs ~5.9 GiB at Laguna's default 16384).
-            args += ["--prefill-chunk", "\(chunk)"]
-        }
-        if let power { args += ["--power", "\(power)"] }
+        if let power, model.supportsPowerCap { args += ["--power", "\(power)"] }
         // >1 preallocates N resident KV sessions so that many chats/agents generate at once.
         // 1 must omit the flag: ds4 treats even `--batched-session 1` as batched mode (MTP off).
         if sessions > 1 { args += ["--batched-session", "\(sessions)"] }

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -10,7 +10,7 @@ struct ModelRowView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Picker("", selection: $app.selectedVariant) {
+            Picker("", selection: Binding(get: { app.selectedVariant }, set: { app.selectedVariant = $0 })) {
                 ForEach(variants) { Text($0.displayName).tag($0) }
             }
             .pickerStyle(.segmented)

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -6,19 +6,26 @@ struct ModelRowView: View {
     @Environment(\.openWindow) private var openWindow
     let ramGiB: Double
 
-    private var variants: [Variant] { ramGiB >= 512 ? [.pro, .flash] : [.flash] }
+    /// Models that can run on this machine (feasibility not blocked). On 64 GB-class
+    /// machines that is just Laguna S 2.1; on this machine, the DS4F variants too.
+    private var runnableModels: [Model] {
+        Model.allCases.filter {
+            if case .blocked = feasibility(ramGiB: ramGiB, model: $0) { return false }
+            return true
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Picker("", selection: Binding(get: { app.selectedVariant }, set: { app.selectedVariant = $0 })) {
-                ForEach(variants) { Text($0.displayName).tag($0) }
+            Picker("", selection: $app.selectedModel) {
+                ForEach(runnableModels) { Text($0.label).tag($0) }
             }
-            .pickerStyle(.segmented)
+            .pickerStyle(.menu)
             .labelsHidden()
             .disabled(supervisor.state == .downloading)  // don't switch model mid-download
 
             let feas = feasibility(
-                ramGiB: ramGiB, variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+                ramGiB: ramGiB, model: app.selectedModel,
                 ctx: app.effectiveCtx(ramGiB: ramGiB),
                 wiredLimitMB: effectiveWiredLimitMB(ramGiB: ramGiB),
                 sessions: app.concurrentSessions,
@@ -29,7 +36,7 @@ struct ModelRowView: View {
     }
 
     @ViewBuilder private func actionButton(_ feas: Feasibility) -> some View {
-        let downloaded = supervisor.isDownloaded(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+        let downloaded = supervisor.isDownloaded(app.selectedModel)
         let blocked: Bool = {
             if case .blocked = feas { return true }
             return false
@@ -48,7 +55,7 @@ struct ModelRowView: View {
             HStack {
                 Button("Retry download") {
                     supervisor.retryDownload(
-                        variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+                        model: app.selectedModel,
                         highPerformance: app.highPerformanceDownload)
                 }
                 .tint(.orange).frame(maxWidth: .infinity).disabled(blocked)
@@ -61,16 +68,16 @@ struct ModelRowView: View {
                     wiredLow ? confirmStartAnyway() : startServer(overrideWiredLimitGate: false)
                 } else {
                     supervisor.retryDownload(
-                        variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+                        model: app.selectedModel,
                         highPerformance: app.highPerformanceDownload)
                 }
             }
             .tint(.orange).frame(maxWidth: .infinity).disabled(blocked)
         default:
             if !downloaded {
-                Button("Download \(app.selectedVariant.displayName)") {
+                Button("Download \(app.selectedModel.displayName)") {
                     supervisor.download(
-                        variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+                        model: app.selectedModel,
                         highPerformance: app.highPerformanceDownload)
                 }
                 .frame(maxWidth: .infinity).disabled(blocked)
@@ -87,7 +94,7 @@ struct ModelRowView: View {
     private func startServer(overrideWiredLimitGate: Bool) {
         let host = app.normalizeHostForLaunch()
         supervisor.start(
-            variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+            model: app.selectedModel,
             ctx: app.effectiveCtx(ramGiB: ramGiB),
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -91,7 +91,8 @@ struct ModelRowView: View {
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
     }
 
     /// Real NSAlert (not SwiftUI .alert, which would collapse the .window MenuBarExtra) —

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -17,11 +17,10 @@ struct ModelRowView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Picker("", selection: $app.selectedModel) {
+            Picker("Model", selection: $app.selectedModel) {
                 ForEach(runnableModels) { Text($0.label).tag($0) }
             }
             .pickerStyle(.menu)
-            .labelsHidden()
             .disabled(supervisor.state == .downloading)  // don't switch model mid-download
 
             let feas = feasibility(

--- a/Sources/DS4Control/Views/ModelRowView.swift
+++ b/Sources/DS4Control/Views/ModelRowView.swift
@@ -21,7 +21,8 @@ struct ModelRowView: View {
                 ramGiB: ramGiB, variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
                 ctx: app.effectiveCtx(ramGiB: ramGiB),
                 wiredLimitMB: effectiveWiredLimitMB(ramGiB: ramGiB),
-                sessions: app.concurrentSessions)
+                sessions: app.concurrentSessions,
+                ssdStreamingCacheGB: app.ssdStreaming ? app.ssdStreamingCacheGB : 0)
             actionButton(feas)
             feasibilityNote(feas)
         }

--- a/Sources/DS4Control/Views/PopupView.swift
+++ b/Sources/DS4Control/Views/PopupView.swift
@@ -142,7 +142,8 @@ struct PopupView: View {
                             contextWindow: supervisor.ctx,
                             allowMaxThink: app.selectedModel.supportsThinkingModes
                                 && supportsMaxThink(ramGiB: ram)
-                                && thinkMax(ctx: supervisor.ctx))                    } else {
+                                && thinkMax(ctx: supervisor.ctx))
+                    } else {
                         showStartHint = true
                     }
                 } label: {

--- a/Sources/DS4Control/Views/PopupView.swift
+++ b/Sources/DS4Control/Views/PopupView.swift
@@ -138,11 +138,11 @@ struct PopupView: View {
                         AgentLauncher.launch(
                             port: supervisor.port,
                             modelId: AgentLauncher.modelId(
-                                for: supervisor.activeModel, fallback: app.selectedVariant),
+                                for: supervisor.activeModel, fallback: app.selectedModel),
                             contextWindow: supervisor.ctx,
-                            allowMaxThink: supportsMaxThink(ramGiB: ram)
-                                && thinkMax(ctx: supervisor.ctx))
-                    } else {
+                            allowMaxThink: app.selectedModel.supportsThinkingModes
+                                && supportsMaxThink(ramGiB: ram)
+                                && thinkMax(ctx: supervisor.ctx))                    } else {
                         showStartHint = true
                     }
                 } label: {

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -95,7 +95,8 @@ struct SettingsView: View {
     private var ctxText: Binding<String> {
         Binding(
             get: {
-                String(app.effectiveCtx(ramGiB: ram))            },
+                String(app.effectiveCtx(ramGiB: ram))
+            },
             set: {
                 let digits = $0.filter(\.isNumber)
                 guard !digits.isEmpty else { app.ctxOverride = 0; return }
@@ -300,7 +301,7 @@ struct SettingsView: View {
     private func restart(overrideWiredLimitGate: Bool = false) {
         let host = app.normalizeHostForLaunch()
         let result = supervisor.restart(
-            model: app.selectedModel,            ctx: app.effectiveCtx(ramGiB: ram),
+            model: app.selectedModel, ctx: app.effectiveCtx(ramGiB: ram),
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -68,6 +68,20 @@ struct SettingsView: View {
     private var sessionsBinding: Binding<Double> {
         Binding(get: { Double(app.concurrentSessions) }, set: { app.concurrentSessions = Int($0.rounded()) })
     }
+    private var streamingCacheBinding: Binding<Double> {
+        Binding(get: { Double(app.ssdStreamingCacheGB) }, set: { app.ssdStreamingCacheGB = Int($0.rounded()) })
+    }
+    private var streamingCacheMaxGiB: Int {
+        max(17, Int(Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant).routedExpertGiB) - 1)
+    }
+    private var streamingCaption: String {
+        let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+        let gb = app.ssdStreamingCacheGB
+        let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+        return
+            "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
+            + "Decode can be slower when the SSD must refill the cache."
+    }
     /// Context-size field as text. Always shows the active window: the override if set, else the
     /// tiered default — so the box is never blank. Backspacing it away stores 0 (auto), which the
     /// getter immediately re-renders as the default value.
@@ -164,6 +178,35 @@ struct SettingsView: View {
                             + "after slot reuse or restart. It does not reduce resident memory. "
                             + "Applies on next server start or restart.")
                 }
+            }
+
+            Section {
+            Section {
+                Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
+                if app.ssdStreaming {
+                    LabeledContent {
+                        HStack(spacing: 10) {
+                            Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
+                            Text("\(app.ssdStreamingCacheGB)")
+                                .monospacedDigit().foregroundStyle(.secondary)
+                                .frame(width: 30, alignment: .trailing)
+                        }
+                        .frame(width: 230)
+                    } label: {
+                        Text("Expert cache")
+                    }
+                    Text(streamingCaption)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } header: {
+                Text("SSD streaming")
+            } footer: {
+                Text(
+                    "Keeps only part of the routed expert weights in RAM and streams the rest "
+                        + "from disk on demand, freeing memory for other apps. "
+                        + "Applies on next server start or restart.")
             }
 
             Section {

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -15,20 +15,24 @@ struct SettingsView: View {
         default: return true
         }
     }
-    /// Downloaded Flash quants other than the selected one — candidates for cleanup.
-    private var removableFlashQuants: [FlashQuant] {
-        FlashQuant.allCases.filter { $0 != app.selectedFlashQuant && supervisor.isFlashQuantDownloaded($0) }
+    /// Downloaded same-family models other than the selected one — candidates for cleanup.
+    /// V4 Pro is excluded by construction (never deleted); Laguna is the only model in its
+    /// family, so nothing is ever removable there.
+    private var removableModels: [Model] {
+        Model.allCases.filter {
+            $0 != app.selectedModel && $0 != .v4Pro && $0.quant != nil && supervisor.isDownloaded($0)
+        }
     }
     private var removableFreedGiB: Int {
-        Int(removableFlashQuants.reduce(0.0) { $0 + $1.quant.weightsGiB })
+        Int(removableModels.reduce(0.0) { $0 + $1.weightsGiB })
     }
-    private var flashModelFooter: String {
+    private var modelFooter: String {
         let base =
-            "Which Flash weights to download and run. Sizes are running memory; "
+            "Which model to download and run. Sizes are running memory; "
             + "options that don't fit this Mac's RAM are unavailable."
         return isBusy
             ? base + " Stop the server to delete unused downloads."
-            : base + " Clean up deletes other downloaded Flash variants (V4 Pro is always kept)."
+            : base + " Clean up deletes other downloaded V4 Flash variants (V4 Pro and other families are always kept)."
     }
 
     private var ctxHint: String {
@@ -39,7 +43,7 @@ struct SettingsView: View {
             return "Max Think is available when context ≥ 393,216."
         }
         return
-            "Auto: \(defaultCtx(ramGiB: ram, variant: app.selectedVariant, flashQuant: app.selectedFlashQuant).formatted()) tokens (based on \(Int(ram)) GiB RAM)."
+            "Auto: \(defaultCtx(ramGiB: ram, model: app.selectedModel).formatted()) tokens (based on \(Int(ram)) GiB RAM)."
     }
 
     private var thinkingHint: String {
@@ -72,14 +76,15 @@ struct SettingsView: View {
         Binding(get: { Double(app.ssdStreamingCacheGB) }, set: { app.ssdStreamingCacheGB = Int($0.rounded()) })
     }
     private var streamingCacheMaxGiB: Int {
-        max(17, Int(Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant).routedExpertGiB) - 1)
+        let expertGiB = app.selectedModel.quant?.routedExpertGiB ?? Quant.q2q4Imatrix.routedExpertGiB
+        return max(17, Int(expertGiB) - 1)
     }
     private var streamingCaption: String {
-        let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+        guard let expertGiB = app.selectedModel.quant?.routedExpertGiB else { return "" }  // Laguna: N/A
         let gb = app.ssdStreamingCacheGB
         // Truncates (82.69 − 67 → ~15 GiB); clamps at 0 so a saved budget larger than
         // the current quant's experts (e.g. after switching quant) never shows negative.
-        let freed = max(0, Int(q.routedExpertGiB - Double(gb)))
+        let freed = max(0, Int(expertGiB - Double(gb)))
         return
             "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
             + "Decode can be slower when the SSD must refill the cache."
@@ -90,8 +95,7 @@ struct SettingsView: View {
     private var ctxText: Binding<String> {
         Binding(
             get: {
-                String(app.effectiveCtx(ramGiB: ram))
-            },
+                String(app.effectiveCtx(ramGiB: ram))            },
             set: {
                 let digits = $0.filter(\.isNumber)
                 guard !digits.isEmpty else { app.ctxOverride = 0; return }
@@ -184,19 +188,29 @@ struct SettingsView: View {
 
             Section {
                 Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
-                if app.ssdStreaming {
-                    LabeledContent {
-                        HStack(spacing: 10) {
-                            Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
-                            Text("\(app.ssdStreamingCacheGB)")
-                                .monospacedDigit().foregroundStyle(.secondary)
-                                .frame(width: 30, alignment: .trailing)
+                    .disabled(!app.selectedModel.supportsSSDStreaming)
+                if app.selectedModel.supportsSSDStreaming {
+                    if app.ssdStreaming {
+                        LabeledContent {
+                            HStack(spacing: 10) {
+                                Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
+                                Text("\(app.ssdStreamingCacheGB)")
+                                    .monospacedDigit().foregroundStyle(.secondary)
+                                    .frame(width: 30, alignment: .trailing)
+                            }
+                            .frame(width: 230)
+                        } label: {
+                            Text("Expert cache")
                         }
-                        .frame(width: 230)
-                    } label: {
-                        Text("Expert cache")
+                        Text(streamingCaption)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                    Text(streamingCaption)
+                } else {
+                    Text(
+                        "SSD streaming isn't supported for Laguna S 2.1 on this ds4 yet — "
+                            + "passing the flag would make the server refuse to start.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -226,36 +240,34 @@ struct SettingsView: View {
             }
 
             Section {
-                Picker(
-                    "Variant", selection: Binding(get: { app.selectedFlashQuant }, set: { app.selectedFlashQuant = $0 })
-                ) {
-                    ForEach(FlashQuant.allCases) { q in
-                        Text(q.label + (supervisor.isFlashQuantDownloaded(q) ? "  (downloaded)" : ""))
-                            .tag(q)
-                            .disabled(!flashQuantFits(q, ramGiB: ram))
+                Picker("Model", selection: $app.selectedModel) {
+                    ForEach(Model.allCases) { m in
+                        Text(m.label + (supervisor.isDownloaded(m) ? "  (downloaded)" : ""))
+                            .tag(m)
+                            .disabled(blocked(m))
                     }
                 }
                 .disabled(supervisor.state == .downloading)  // locked while a download is in progress
-                Button("Clean up unused Flash downloads") { confirmingCleanup = true }
-                    .disabled(removableFlashQuants.isEmpty || isBusy)
+                Button("Clean up unused downloads") { confirmingCleanup = true }
+                    .disabled(removableModels.isEmpty || isBusy)
             } header: {
-                Text("V4 Flash model")
+                Text("Model")
             } footer: {
-                Text(flashModelFooter)
+                Text(modelFooter)
             }
             .confirmationDialog(
                 "Delete other V4 Flash downloads?", isPresented: $confirmingCleanup,
                 titleVisibility: .visible
             ) {
                 Button(
-                    "Delete \(removableFlashQuants.count) file(s) · ~\(removableFreedGiB) GiB",
+                    "Delete \(removableModels.count) file(s) · ~\(removableFreedGiB) GiB",
                     role: .destructive
                 ) {
-                    supervisor.cleanupUnusedFlashQuants(keep: app.selectedFlashQuant)
+                    supervisor.cleanupUnusedModels(keep: app.selectedModel)
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("Keeps the selected variant and V4 Pro. Deleted weights must be downloaded again.")
+                Text("Keeps the selected model, V4 Pro, and other families. Deleted weights must be downloaded again.")
             }
 
             Section {
@@ -287,8 +299,7 @@ struct SettingsView: View {
     private func restart(overrideWiredLimitGate: Bool = false) {
         let host = app.normalizeHostForLaunch()
         let result = supervisor.restart(
-            variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
-            ctx: app.effectiveCtx(ramGiB: ram),
+            model: app.selectedModel,            ctx: app.effectiveCtx(ramGiB: ram),
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
@@ -302,5 +313,10 @@ struct SettingsView: View {
                 restart(overrideWiredLimitGate: true)
             }
         }
+    }
+
+    private func blocked(_ m: Model) -> Bool {
+        if case .blocked = feasibility(ramGiB: ram, model: m) { return true }
+        return false
     }
 }

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -246,7 +246,8 @@ struct SettingsView: View {
             host: host, port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
         if case let .rejected(feasibility) = result {
             RestartRejectionAlert.show(
                 feasibility,

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -226,7 +226,7 @@ struct SettingsView: View {
             }
 
             Section {
-                Picker("Variant", selection: $app.selectedFlashQuant) {
+                Picker("Variant", selection: Binding(get: { app.selectedFlashQuant }, set: { app.selectedFlashQuant = $0 })) {
                     ForEach(FlashQuant.allCases) { q in
                         Text(q.label + (supervisor.isFlashQuantDownloaded(q) ? "  (downloaded)" : ""))
                             .tag(q)

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -183,7 +183,6 @@ struct SettingsView: View {
             }
 
             Section {
-            Section {
                 Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
                 if app.ssdStreaming {
                     LabeledContent {

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -226,7 +226,9 @@ struct SettingsView: View {
             }
 
             Section {
-                Picker("Variant", selection: Binding(get: { app.selectedFlashQuant }, set: { app.selectedFlashQuant = $0 })) {
+                Picker(
+                    "Variant", selection: Binding(get: { app.selectedFlashQuant }, set: { app.selectedFlashQuant = $0 })
+                ) {
                     ForEach(FlashQuant.allCases) { q in
                         Text(q.label + (supervisor.isFlashQuantDownloaded(q) ? "  (downloaded)" : ""))
                             .tag(q)

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -210,10 +210,11 @@ struct SettingsView: View {
                 } else {
                     Text(
                         "SSD streaming isn't supported for Laguna S 2.1 on this ds4 yet — "
-                            + "passing the flag would make the server refuse to start.")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                            + "passing the flag would make the server refuse to start."
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             } header: {
                 Text("SSD streaming")

--- a/Sources/DS4Control/Views/SettingsView.swift
+++ b/Sources/DS4Control/Views/SettingsView.swift
@@ -77,7 +77,9 @@ struct SettingsView: View {
     private var streamingCaption: String {
         let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
         let gb = app.ssdStreamingCacheGB
-        let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+        // Truncates (82.69 − 67 → ~15 GiB); clamps at 0 so a saved budget larger than
+        // the current quant's experts (e.g. after switching quant) never shows negative.
+        let freed = max(0, Int(q.routedExpertGiB - Double(gb)))
         return
             "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
             + "Decode can be slower when the SSD must refill the cache."

--- a/Sources/DS4Control/Views/ThinkingModeControls.swift
+++ b/Sources/DS4Control/Views/ThinkingModeControls.swift
@@ -131,7 +131,7 @@ enum ThinkingModePrompt {
             return .rejected(.blocked(reason: maxThinkUnavailableReason))
         }
         let result = supervisor.restart(
-            variant: app.selectedVariant, flashQuant: app.selectedFlashQuant,
+            model: app.selectedModel,
             ctx: thinkMaxMinCtx,
             host: app.normalizeHostForLaunch(), port: app.port, power: app.power,
             sessions: app.concurrentSessions,

--- a/Sources/DS4Control/Views/ThinkingModeControls.swift
+++ b/Sources/DS4Control/Views/ThinkingModeControls.swift
@@ -132,7 +132,8 @@ enum ThinkingModePrompt {
             host: app.normalizeHostForLaunch(), port: app.port, power: app.power,
             sessions: app.concurrentSessions,
             kvDiskDir: app.kvDiskCache ? supervisor.kvDiskCacheURL : nil,
-            overrideWiredLimitGate: overrideWiredLimitGate)
+            overrideWiredLimitGate: overrideWiredLimitGate,
+            ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB)
         if result == .accepted { app.applyMaxThinkCtxBump(ramGiB: ramGiB) }
         return result
     }

--- a/Sources/DS4Control/Views/ThinkingModeControls.swift
+++ b/Sources/DS4Control/Views/ThinkingModeControls.swift
@@ -10,12 +10,16 @@ struct ThinkingModePicker: View {
     private let ram = systemRamGiB()
 
     var body: some View {
-        Picker("Thinking:", selection: binding) {
-            ForEach(availableModes) { mode in
-                Text(mode.label).tag(mode)
-            }
+        // Thinking tiers (Instant/Standard/Max Think) are DS4F semantics. Laguna S 2.1
+        // uses its own native interleaved reasoning — no picker, ds4's default stands.
+        if app.selectedModel.supportsThinkingModes {
+            Picker("Thinking:", selection: binding) {
+                ForEach(availableModes) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }            }
+            .pickerStyle(.segmented)
         }
-        .pickerStyle(.segmented)
     }
 
     private var serverRunning: Bool { supervisor.state == .ready || supervisor.state == .starting }

--- a/Sources/DS4Control/Views/ThinkingModeControls.swift
+++ b/Sources/DS4Control/Views/ThinkingModeControls.swift
@@ -17,7 +17,7 @@ struct ThinkingModePicker: View {
                 ForEach(availableModes) { mode in
                     Text(mode.label).tag(mode)
                 }
-            }            }
+            }
             .pickerStyle(.segmented)
         }
     }

--- a/Tests/DS4ControlTests/AgentLauncherTests.swift
+++ b/Tests/DS4ControlTests/AgentLauncherTests.swift
@@ -4,14 +4,20 @@ import XCTest
 
 final class AgentLauncherTests: XCTestCase {
     func testModelIdPrefersRunningModel() {
-        XCTAssertEqual(AgentLauncher.modelId(for: "deepseek-v4-pro", fallback: .flash), "deepseek-v4-pro")
-        XCTAssertEqual(AgentLauncher.modelId(for: "deepseek-v4-flash", fallback: .pro), "deepseek-v4-flash")
+        XCTAssertEqual(AgentLauncher.modelId(for: "deepseek-v4-pro", fallback: .v4FlashQ2Q4), "deepseek-v4-pro")
+        XCTAssertEqual(AgentLauncher.modelId(for: "deepseek-v4-flash", fallback: .v4Pro), "deepseek-v4-flash")
+        XCTAssertEqual(AgentLauncher.modelId(for: "laguna-s-2.1", fallback: .v4Pro), "laguna-s-2.1")
     }
 
     func testModelIdFallsBackWhenNilOrUnknown() {
-        XCTAssertEqual(AgentLauncher.modelId(for: nil, fallback: .pro), "deepseek-v4-pro")
+        XCTAssertEqual(AgentLauncher.modelId(for: nil, fallback: .v4Pro), "deepseek-v4-pro")
         // Orphan-attach case: activeModel is a server display name, not a known model id.
-        XCTAssertEqual(AgentLauncher.modelId(for: "ds4-server", fallback: .flash), "deepseek-v4-flash")
+        XCTAssertEqual(AgentLauncher.modelId(for: "ds4-server", fallback: .v4FlashQ2Q4), "deepseek-v4-flash")
+        XCTAssertEqual(AgentLauncher.modelId(for: nil, fallback: .lagunaS21), "laguna-s-2.1")
+    }
+
+    func testKnownModelIdsIncludesLaguna() {
+        XCTAssertTrue(AgentLauncher.knownModelIds.contains("laguna-s-2.1"))
     }
 
     func testPiModelsJSONValidAndPointsAtLocalServer() throws {
@@ -22,6 +28,7 @@ final class AgentLauncherTests: XCTestCase {
         XCTAssertTrue(s.contains("openai-completions"))
         XCTAssertTrue(s.contains("deepseek-v4-pro"))
         XCTAssertTrue(s.contains("deepseek-v4-flash"))
+        XCTAssertTrue(s.contains("\"id\": \"laguna-s-2.1\""))
         XCTAssertTrue(s.contains("thinkingLevelMap"))
         XCTAssertTrue(s.contains("\"xhigh\": \"max\""))  // Max mode (pi xhigh) → ds4 reasoning_effort "max"
     }

--- a/Tests/DS4ControlTests/AppStateTests.swift
+++ b/Tests/DS4ControlTests/AppStateTests.swift
@@ -6,11 +6,11 @@ final class AppStateTests: XCTestCase {
     func testEffectiveCtxFallsBackToDefault() {
         let d = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
         let app = AppState(defaults: d)
-        app.selectedVariant = .flash
+        app.selectedModel = .v4FlashQ2
         app.ctxOverride = 0
         XCTAssertEqual(
             app.effectiveCtx(ramGiB: 128),
-            defaultCtx(ramGiB: 128, variant: .flash, flashQuant: app.selectedFlashQuant))
+            defaultCtx(ramGiB: 128, model: app.selectedModel))
         app.ctxOverride = 50_000
         XCTAssertEqual(app.effectiveCtx(ramGiB: 128), 50_000)
         app.ctxOverride = Int.max
@@ -125,14 +125,6 @@ final class AppStateTests: XCTestCase {
         let app = AppState(defaults: d)
         XCTAssertEqual(app.selectedModel, .v4FlashQ2)  // mapped from the legacy pair
     }
-    func testSelectedModelShimsRoundTrip() {
-        let app = AppState(defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!)
-        app.selectedVariant = .pro
-        XCTAssertEqual(app.selectedModel, .v4Pro)
-        app.selectedFlashQuant = .q2
-        XCTAssertEqual(app.selectedModel, .v4FlashQ2)
-    }
-
     func testThinkingModeGateAndCtxBump() {
         let lowMemoryApp = AppState(
             defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!, ramGiB: 96)
@@ -175,9 +167,8 @@ final class AppStateTests: XCTestCase {
     func testSsdStreamingCacheGBDefaultsToFree15BudgetAndPersists() {
         let name = "test.\(UUID().uuidString)"
         let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
-        XCTAssertEqual(
-            a1.ssdStreamingCacheGB,
-            Quant.for(a1.selectedVariant, flashQuant: a1.selectedFlashQuant).defaultStreamingCacheGB)
+        // The fresh-install budget is the ~15 GiB-free value for the default DS4F quant.
+        XCTAssertEqual(a1.ssdStreamingCacheGB, Quant.q2q4Imatrix.defaultStreamingCacheGB)
         a1.ssdStreamingCacheGB = 80
         let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
         XCTAssertEqual(a2.ssdStreamingCacheGB, 80)  // persisted, not re-defaulted

--- a/Tests/DS4ControlTests/AppStateTests.swift
+++ b/Tests/DS4ControlTests/AppStateTests.swift
@@ -105,6 +105,34 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(defaults.integer(forKey: "ctxOverride"), 0)
     }
 
+    func testSelectedModelDefaultsByRAM() {
+        let app = AppState(defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!)
+        // On this machine (≥128 GiB) the default is v4FlashQ2Q4, matching the old
+        // defaultFlashQuant behavior (tiered by real system RAM like the existing tests).
+        XCTAssertEqual(app.selectedModel, .v4FlashQ2Q4)
+    }
+    func testSelectedModelPersists() {
+        let name = "test.\(UUID().uuidString)"
+        let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+        a1.selectedModel = .lagunaS21
+        let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertEqual(a2.selectedModel, .lagunaS21)
+    }
+    func testSelectedModelMigratesLegacyVariantKeys() {
+        let d = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        d.set(Variant.flash.rawValue, forKey: "selectedVariant")
+        d.set(FlashQuant.q2.rawValue, forKey: "selectedFlashQuant")
+        let app = AppState(defaults: d)
+        XCTAssertEqual(app.selectedModel, .v4FlashQ2)  // mapped from the legacy pair
+    }
+    func testSelectedModelShimsRoundTrip() {
+        let app = AppState(defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!)
+        app.selectedVariant = .pro
+        XCTAssertEqual(app.selectedModel, .v4Pro)
+        app.selectedFlashQuant = .q2
+        XCTAssertEqual(app.selectedModel, .v4FlashQ2)
+    }
+
     func testThinkingModeGateAndCtxBump() {
         let lowMemoryApp = AppState(
             defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!, ramGiB: 96)

--- a/Tests/DS4ControlTests/AppStateTests.swift
+++ b/Tests/DS4ControlTests/AppStateTests.swift
@@ -135,4 +135,23 @@ final class AppStateTests: XCTestCase {
             app2.requestThinkingMode(.max, currentCtx: 393_216, ramGiB: 128), .applied)
         XCTAssertEqual(app2.thinkingMode, .max)
     }
+
+    func testSsdStreamingDefaultsOnAndPersists() {
+        let name = "test.\(UUID().uuidString)"
+        let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertTrue(a1.ssdStreaming)  // default ON — frees ~15 GiB on fresh installs
+        a1.ssdStreaming = false
+        let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertFalse(a2.ssdStreaming)  // persisted
+    }
+    func testSsdStreamingCacheGBDefaultsToFree15BudgetAndPersists() {
+        let name = "test.\(UUID().uuidString)"
+        let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertEqual(
+            a1.ssdStreamingCacheGB,
+            Quant.for(a1.selectedVariant, flashQuant: a1.selectedFlashQuant).defaultStreamingCacheGB)
+        a1.ssdStreamingCacheGB = 80
+        let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+        XCTAssertEqual(a2.ssdStreamingCacheGB, 80)  // persisted, not re-defaulted
+    }
 }

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -54,4 +54,14 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(thinking.contains(pattern))
         XCTAssertTrue(settings.contains(pattern))
     }
+
+    func testSettingsHasSsdStreamingSection() throws {
+        let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+        XCTAssertTrue(settings.contains(#""Stream expert weights from SSD""#))
+        XCTAssertTrue(settings.contains(#"Text("SSD streaming")"#))
+        XCTAssertTrue(settings.contains("ssdStreamingCacheGB"))
+        XCTAssertTrue(settings.contains("routedExpertGiB"))
+        // Caption shows the freed amount for the selected quant.
+        XCTAssertTrue(settings.contains("frees ~"))
+    }
 }

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -65,4 +65,10 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         // Caption shows the freed amount for the selected quant.
         XCTAssertTrue(settings.contains("frees ~"))
     }
+    func testThinkingPickerGatedForLaguna() throws {
+        let picker = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+        XCTAssertTrue(picker.contains("supportsThinkingModes"))
+        XCTAssertTrue(picker.contains("selectedModel"))
+    }
+
 }

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -42,6 +42,7 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(settings.contains("if !supportsMaxThink(ramGiB: ram)"))
         XCTAssertTrue(settings.contains("Max Think requires at least 128 GiB unified memory."))
         XCTAssertTrue(settings.contains("Max Think is unavailable below 128 GiB unified memory."))
+    }
     func testModelRowStartThreadsSsdStreamingSetting() throws {
         let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
         // Both Start paths route through startServer(_:), which carries the setting.

--- a/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+++ b/Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
@@ -42,5 +42,16 @@ final class ChatThinkMaxToggleTests: XCTestCase {
         XCTAssertTrue(settings.contains("if !supportsMaxThink(ramGiB: ram)"))
         XCTAssertTrue(settings.contains("Max Think requires at least 128 GiB unified memory."))
         XCTAssertTrue(settings.contains("Max Think is unavailable below 128 GiB unified memory."))
+    func testModelRowStartThreadsSsdStreamingSetting() throws {
+        let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
+        // Both Start paths route through startServer(_:), which carries the setting.
+        XCTAssertTrue(modelRow.contains("ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"))
+    }
+    func testRestartCallSitesThreadSsdStreamingSetting() throws {
+        let thinking = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+        let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+        let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+        XCTAssertTrue(thinking.contains(pattern))
+        XCTAssertTrue(settings.contains(pattern))
     }
 }

--- a/Tests/DS4ControlTests/FeasibilityTests.swift
+++ b/Tests/DS4ControlTests/FeasibilityTests.swift
@@ -287,8 +287,14 @@ final class FeasibilityTests: XCTestCase {
 
     func testLagunaFeasibilityTiers() {
         if case .blocked = feasibility(ramGiB: 63, model: .lagunaS21) {} else { XCTFail("63 GiB must block") }
-        if case .warnWiredLimit = feasibility(ramGiB: 64, model: .lagunaS21) {} else { XCTFail("64 GiB must warn wired limit") }
-        if case .warnWiredLimit = feasibility(ramGiB: 95, model: .lagunaS21) {} else { XCTFail("95 GiB must warn wired limit") }
+        if case .warnWiredLimit = feasibility(ramGiB: 64, model: .lagunaS21) {
+        } else {
+            XCTFail("64 GiB must warn wired limit")
+        }
+        if case .warnWiredLimit = feasibility(ramGiB: 95, model: .lagunaS21) {
+        } else {
+            XCTFail("95 GiB must warn wired limit")
+        }
         XCTAssertEqual(feasibility(ramGiB: 96, model: .lagunaS21), .standard)
         // Wired-limit advisory leaves the 8 GiB OS buffer, like the DS4F tiers.
         if case let .warnWiredLimit(mb) = feasibility(ramGiB: 64, model: .lagunaS21) {

--- a/Tests/DS4ControlTests/FeasibilityTests.swift
+++ b/Tests/DS4ControlTests/FeasibilityTests.swift
@@ -286,22 +286,12 @@ final class FeasibilityTests: XCTestCase {
     func testWiredLimitReadable() { XCTAssertGreaterThanOrEqual(currentWiredLimitMB(), 0) }
 
     func testLagunaFeasibilityTiers() {
+        // RAM-tier only (the config-specific Metal wired-limit gate is DS4F-only for now):
+        // Laguna q2-q3 fits 64 GiB+, blocked below.
         if case .blocked = feasibility(ramGiB: 63, model: .lagunaS21) {} else { XCTFail("63 GiB must block") }
-        if case .warnWiredLimit = feasibility(ramGiB: 64, model: .lagunaS21) {
-        } else {
-            XCTFail("64 GiB must warn wired limit")
-        }
-        if case .warnWiredLimit = feasibility(ramGiB: 95, model: .lagunaS21) {
-        } else {
-            XCTFail("95 GiB must warn wired limit")
-        }
+        XCTAssertEqual(feasibility(ramGiB: 64, model: .lagunaS21), .standard)
+        XCTAssertEqual(feasibility(ramGiB: 95, model: .lagunaS21), .standard)
         XCTAssertEqual(feasibility(ramGiB: 96, model: .lagunaS21), .standard)
-        // Wired-limit advisory leaves the 8 GiB OS buffer, like the DS4F tiers.
-        if case let .warnWiredLimit(mb) = feasibility(ramGiB: 64, model: .lagunaS21) {
-            XCTAssertEqual(mb, Int((64.0 - 8.0) * 1024))
-        } else {
-            XCTFail("laguna 64 warns")
-        }
     }
     func testLagunaDefaultCtx() {
         XCTAssertEqual(defaultCtx(ramGiB: 64, model: .lagunaS21), 50_000)

--- a/Tests/DS4ControlTests/FeasibilityTests.swift
+++ b/Tests/DS4ControlTests/FeasibilityTests.swift
@@ -284,6 +284,23 @@ final class FeasibilityTests: XCTestCase {
     }
     func testSystemRam() { XCTAssertGreaterThan(systemRamGiB(), 0) }
     func testWiredLimitReadable() { XCTAssertGreaterThanOrEqual(currentWiredLimitMB(), 0) }
+
+    func testLagunaFeasibilityTiers() {
+        if case .blocked = feasibility(ramGiB: 63, model: .lagunaS21) {} else { XCTFail("63 GiB must block") }
+        if case .warnWiredLimit = feasibility(ramGiB: 64, model: .lagunaS21) {} else { XCTFail("64 GiB must warn wired limit") }
+        if case .warnWiredLimit = feasibility(ramGiB: 95, model: .lagunaS21) {} else { XCTFail("95 GiB must warn wired limit") }
+        XCTAssertEqual(feasibility(ramGiB: 96, model: .lagunaS21), .standard)
+        // Wired-limit advisory leaves the 8 GiB OS buffer, like the DS4F tiers.
+        if case let .warnWiredLimit(mb) = feasibility(ramGiB: 64, model: .lagunaS21) {
+            XCTAssertEqual(mb, Int((64.0 - 8.0) * 1024))
+        } else {
+            XCTFail("laguna 64 warns")
+        }
+    }
+    func testLagunaDefaultCtx() {
+        XCTAssertEqual(defaultCtx(ramGiB: 64, model: .lagunaS21), 50_000)
+        XCTAssertEqual(defaultCtx(ramGiB: 128, model: .lagunaS21), 50_000)
+    }
 }
 
 extension FeasibilityTests {

--- a/Tests/DS4ControlTests/FeasibilityTests.swift
+++ b/Tests/DS4ControlTests/FeasibilityTests.swift
@@ -285,3 +285,17 @@ final class FeasibilityTests: XCTestCase {
     func testSystemRam() { XCTAssertGreaterThan(systemRamGiB(), 0) }
     func testWiredLimitReadable() { XCTAssertGreaterThanOrEqual(currentWiredLimitMB(), 0) }
 }
+
+extension FeasibilityTests {
+    func testRequiredWiredMBShrinksWhenSsdStreaming() {
+        // SSD streaming keeps only the expert-cache budget + non-routed weights resident,
+        // so the gate must not charge the full GGUF for routed experts.
+        let full = requiredWiredMB(variant: .flash, flashQuant: .q2, ctx: 1_000_000)
+        let streamed = requiredWiredMB(
+            variant: .flash, flashQuant: .q2, ctx: 1_000_000, ssdStreamingCacheGB: 67)
+        // q2: routed experts 73 GiB, cache 67 → ~6 GiB less resident; full is ~80.8 GiB
+        // weights vs ~74.8 resident. Expect a meaningful drop, not a full-weights charge.
+        XCTAssertLessThan(streamed, full)
+        XCTAssertGreaterThan(full - streamed, 4 * 1024)  // > ~4 GiB freed
+    }
+}

--- a/Tests/DS4ControlTests/HFDownloaderTests.swift
+++ b/Tests/DS4ControlTests/HFDownloaderTests.swift
@@ -169,4 +169,13 @@ final class HFDownloaderTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: sidecar.path), "sidecar dropped on completion")
         XCTAssertFalse(FileManager.default.fileExists(atPath: part.path), ".part renamed away on completion")
     }
+
+    func testLagunaRepoResolveURL() {
+        let url = URL(
+            string:
+                "https://huggingface.co/antirez/Laguna-S-2.1-GGUF/resolve/main/laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")!
+        XCTAssertEqual(
+            url.path, "/antirez/Laguna-S-2.1-GGUF/resolve/main/laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+    }
+
 }

--- a/Tests/DS4ControlTests/ModelTests.swift
+++ b/Tests/DS4ControlTests/ModelTests.swift
@@ -32,10 +32,10 @@ final class ModelTests: XCTestCase {
             "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
         XCTAssertNil(Model.lagunaS21.routedExpertGiB)  // SSD streaming N/A
     }
-    func testCtxCeilingAndPrefill() {
+    func testCtxCeilingAndPowerCap() {
         XCTAssertEqual(Model.lagunaS21.ctxCeiling, 262_144)  // GGUF laguna.context_length
         XCTAssertEqual(Model.v4FlashQ2Q4.ctxCeiling, 1_000_000)
-        XCTAssertEqual(Model.lagunaS21.defaultPrefillChunk, 4096)
-        XCTAssertNil(Model.v4FlashQ2Q4.defaultPrefillChunk)
+        XCTAssertFalse(Model.lagunaS21.supportsPowerCap)  // ds4 standard-graph-only gate
+        XCTAssertTrue(Model.v4FlashQ2Q4.supportsPowerCap)
     }
 }

--- a/Tests/DS4ControlTests/ModelTests.swift
+++ b/Tests/DS4ControlTests/ModelTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import DS4Control
+
+final class ModelTests: XCTestCase {
+    func testAllCasesAndLabels() {
+        XCTAssertEqual(Model.allCases, [.v4Pro, .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4, .lagunaS21])
+        XCTAssertEqual(Model.v4Pro.displayName, "V4 Pro")
+        XCTAssertEqual(Model.v4FlashQ2Q4.displayName, "V4 Flash")
+        XCTAssertEqual(Model.lagunaS21.displayName, "Laguna S 2.1")
+        XCTAssertEqual(Model.v4FlashQ4.label, "V4 Flash · ~153 GiB")
+        XCTAssertEqual(Model.lagunaS21.label, "Laguna S 2.1 · ~45 GiB")
+    }
+    func testModelIds() {
+        XCTAssertEqual(Model.v4Pro.modelId, "deepseek-v4-pro")
+        XCTAssertEqual(Model.v4FlashQ2Q4.modelId, "deepseek-v4-flash")
+        XCTAssertEqual(Model.lagunaS21.modelId, "laguna-s-2.1")
+    }
+    func testQuantMappingAndCapabilities() {
+        XCTAssertEqual(Model.v4FlashQ2Q4.quant, .q2q4Imatrix)
+        XCTAssertNil(Model.lagunaS21.quant)  // no DS4F quant
+        XCTAssertTrue(Model.v4FlashQ2Q4.supportsSSDStreaming)
+        XCTAssertFalse(Model.lagunaS21.supportsSSDStreaming)  // ds4 hard gate
+        XCTAssertTrue(Model.v4FlashQ2Q4.supportsThinkingModes)
+        XCTAssertFalse(Model.lagunaS21.supportsThinkingModes)  // v1: native reasoning, no picker
+    }
+    func testLagunaDownloadAndSizeFacts() {
+        XCTAssertEqual(Model.lagunaS21.weightsGiB, 44.95, accuracy: 0.01)
+        XCTAssertEqual(Model.lagunaS21.downloadRepo, "antirez/Laguna-S-2.1-GGUF")
+        XCTAssertEqual(Model.lagunaS21.downloadRevision, "main")
+        XCTAssertEqual(
+            Model.lagunaS21.ggufFilename,
+            "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+        XCTAssertNil(Model.lagunaS21.routedExpertGiB)  // SSD streaming N/A
+    }
+    func testCtxCeilingAndPrefill() {
+        XCTAssertEqual(Model.lagunaS21.ctxCeiling, 262_144)  // GGUF laguna.context_length
+        XCTAssertEqual(Model.v4FlashQ2Q4.ctxCeiling, 1_000_000)
+        XCTAssertEqual(Model.lagunaS21.defaultPrefillChunk, 4096)
+        XCTAssertNil(Model.v4FlashQ2Q4.defaultPrefillChunk)
+    }
+}

--- a/Tests/DS4ControlTests/SupervisorIntegrationTests.swift
+++ b/Tests/DS4ControlTests/SupervisorIntegrationTests.swift
@@ -171,7 +171,7 @@ final class SupervisorIntegrationTests: XCTestCase {
 
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in .standard })  // host-independent: skip the RAM/sysctl gate
+            wiredLimitGate: { _, _, _, _, _ in .standard })  // host-independent: skip the RAM/sysctl gate
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8137, power: nil)
         let ready = expectation(description: "ready")
         let token = s.$state.sink { if $0 == .ready { ready.fulfill() } }
@@ -194,7 +194,7 @@ final class SupervisorIntegrationTests: XCTestCase {
         let expectedAdvisory = expectedRequired + 1024
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in
+            wiredLimitGate: { _, _, _, _, _ in
                 .wiredLimitTooLow(requiredMB: expectedRequired, advisoryMB: expectedAdvisory)
             })
         s.start(variant: .flash, flashQuant: .q2, ctx: 393_216, host: "127.0.0.1", port: 8137, power: nil)
@@ -225,7 +225,7 @@ final class SupervisorIntegrationTests: XCTestCase {
         let rejection = Feasibility.wiredLimitTooLow(requiredMB: 100_000, advisoryMB: 110_000)
         let s = SupervisorService(
             ds4Dir: dir, runner: RealProcessRunner(),
-            wiredLimitGate: { _, _, _, _ in gateOpen ? .standard : rejection })
+            wiredLimitGate: { _, _, _, _, _ in gateOpen ? .standard : rejection })
         s.start(variant: .flash, flashQuant: .q2, ctx: 393_216, host: "127.0.0.1", port: 8137, power: nil)
         guard case .starting = s.state else { return XCTFail("expected .starting, got \(s.state)") }
         gateOpen = false

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -324,6 +324,39 @@ final class SupervisorStateMachineTests: XCTestCase {
         XCTAssertEqual(
             r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
     }
+    func testLagunaLaunchPassesPrefillChunkAndNeverSsdStreaming() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
+        for f in ["ds4-server", "download_model.sh"] {
+            let u = dir.appendingPathComponent(f);
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
+".utf8))
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
+        }
+        let gg = dir.appendingPathComponent("gguf").appendingPathComponent(Model.lagunaS21.ggufFilename)
+        FileManager.default.createFile(atPath: gg.path, contents: Data("gguf".utf8))
+        let r = FakeRunner()
+        let s = SupervisorService(ds4Dir: dir, runner: r)
+        // The global SSD-streaming setting is ON — it must be inert for Laguna.
+        s.start(
+            model: .lagunaS21, ctx: 50_000, host: "127.0.0.1", port: 8000, power: nil,
+            ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--prefill-chunk"))
+        XCTAssertEqual(r.lastArgs[r.lastArgs.firstIndex(of: "--prefill-chunk")! + 1], "4096")
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+        XCTAssertTrue(r.lastArgs.contains { $0.contains("laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf") })
+    }
+    func testDs4fLaunchStillPassesSsdStreamingWhenEnabled() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(
+            model: .v4FlashQ2Q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil,
+            ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
+    }
+
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -338,22 +338,25 @@ final class SupervisorStateMachineTests: XCTestCase {
         FileManager.default.createFile(atPath: gg.path, contents: Data("gguf".utf8))
         let r = FakeRunner()
         let s = SupervisorService(ds4Dir: dir, runner: r)
-        // The global SSD-streaming setting is ON — it must be inert for Laguna.
+        // ds4 gates Laguna to the standard local graph path: no SSD streaming, no power
+        // cap, no custom prefill chunk — any of them makes the server refuse to start.
         s.start(
-            model: .lagunaS21, ctx: 50_000, host: "127.0.0.1", port: 8000, power: nil,
+            model: .lagunaS21, ctx: 50_000, host: "127.0.0.1", port: 8000, power: 80,
             ssdStreaming: true, ssdStreamingCacheGB: 67)
-        XCTAssertTrue(r.lastArgs.contains("--prefill-chunk"))
-        XCTAssertEqual(r.lastArgs[r.lastArgs.firstIndex(of: "--prefill-chunk")! + 1], "4096")
         XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
         XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+        XCTAssertFalse(r.lastArgs.contains("--power"))
+        XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
         XCTAssertTrue(r.lastArgs.contains { $0.contains("laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf") })
     }
     func testDs4fLaunchStillPassesSsdStreamingWhenEnabled() throws {
         let r = FakeRunner(); let s = try makeSupervisor(r)
         s.start(
-            model: .v4FlashQ2Q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil,
+            model: .v4FlashQ2Q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: 80,
             ssdStreaming: true, ssdStreamingCacheGB: 67)
         XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertTrue(r.lastArgs.contains("--power"))
+        XCTAssertEqual(r.lastArgs[r.lastArgs.firstIndex(of: "--power")! + 1], "80")
         XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
     }
     func testLagunaDownloadUsesLagunaFile() throws {

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -32,7 +32,7 @@ final class SupervisorStateMachineTests: XCTestCase {
     // adoption probe, and the real default would hit a live ds4-server on the dev machine.
     fileprivate func makeSupervisor(
         _ runner: FakeRunner, probe: @escaping (Int) async -> Data? = { _ in nil },
-        wiredLimitGate: @escaping SupervisorService.WiredLimitGate = { _, _, _, _ in .standard }
+        wiredLimitGate: @escaping SupervisorService.WiredLimitGate = { _, _, _, _, _ in .standard }
     ) throws -> SupervisorService {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(
@@ -141,7 +141,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         var gatedSessions: [Int] = []
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, _, sessions in
+            wiredLimitGate: { _, _, _, sessions, _ in
                 gatedSessions.append(sessions)
                 return .standard
             })
@@ -213,7 +213,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         let rejection = Feasibility.wiredLimitTooLow(requiredMB: 100_000, advisoryMB: 110_000)
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, ctx, _ in ctx == thinkMaxMinCtx ? rejection : .standard })
+            wiredLimitGate: { _, _, ctx, _, _ in ctx == thinkMaxMinCtx ? rejection : .standard })
         s.start(
             variant: .flash, flashQuant: .q2q4, ctx: 100_000,
             host: "127.0.0.1", port: 8000, power: nil)
@@ -248,7 +248,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         var gateCalls = 0
         let s = try makeSupervisor(
             r,
-            wiredLimitGate: { _, _, _, _ in
+            wiredLimitGate: { _, _, _, _, _ in
                 gateCalls += 1
                 return .standard
             })
@@ -286,7 +286,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         }
         let s = SupervisorService(
             ds4Dir: dir, runner: FakeRunner(),
-            wiredLimitGate: { _, _, _, _ in .standard })
+            wiredLimitGate: { _, _, _, _, _ in .standard })
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
         if case .error(.modelMissing) = s.state {} else { XCTFail("expected modelMissing, got \(s.state)") }
     }

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -356,29 +356,14 @@ final class SupervisorStateMachineTests: XCTestCase {
         XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
         XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
     }
-<<<<<<< HEAD
-
-=======
-    func testServerSpeedHistoryCapsAndResetsOnStart() throws {
-        let r = FakeRunner(); let s = try makeSupervisor(r)
-        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
-        let decodeLine =
-            "ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s"
-        for _ in 0..<70 { r.emit(decodeLine) }
-        XCTAssertEqual(s.serverSpeedHistory.count, 60)  // capped
-        r.crash(1)  // server dies
-        // A fresh start clears the stale speed/history.
-        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
-        XCTAssertNil(s.serverSpeed)
-        XCTAssertTrue(s.serverSpeedHistory.isEmpty)
-    }
     func testLagunaDownloadUsesLagunaFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(
             at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
         for f in ["ds4-server", "download_model.sh"] {
             let u = dir.appendingPathComponent(f)
-            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
+".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
         }
         let s = SupervisorService(
@@ -395,7 +380,8 @@ final class SupervisorStateMachineTests: XCTestCase {
             at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
         for f in ["ds4-server", "download_model.sh"] {
             let u = dir.appendingPathComponent(f)
-            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
+".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
         }
         let ggufDir = dir.appendingPathComponent("gguf")
@@ -416,7 +402,7 @@ final class SupervisorStateMachineTests: XCTestCase {
         // Cleaning when keeping Laguna is a no-op (single model per family).
         XCTAssertTrue(s.cleanupUnusedModels(keep: .lagunaS21).isEmpty)
     }
->>>>>>> 09f6263 (feat: per-model downloader (Laguna repo) and family-scoped cleanup)
+
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -356,7 +356,67 @@ final class SupervisorStateMachineTests: XCTestCase {
         XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
         XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
     }
+<<<<<<< HEAD
 
+=======
+    func testServerSpeedHistoryCapsAndResetsOnStart() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        let decodeLine =
+            "ds4-server: chat ctx=52..57:5 gen=5 decoding chunk=41.40 t/s avg=41.40 t/s 0.121s"
+        for _ in 0..<70 { r.emit(decodeLine) }
+        XCTAssertEqual(s.serverSpeedHistory.count, 60)  // capped
+        r.crash(1)  // server dies
+        // A fresh start clears the stale speed/history.
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        XCTAssertNil(s.serverSpeed)
+        XCTAssertTrue(s.serverSpeedHistory.isEmpty)
+    }
+    func testLagunaDownloadUsesLagunaFile() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
+        for f in ["ds4-server", "download_model.sh"] {
+            let u = dir.appendingPathComponent(f)
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
+        }
+        let s = SupervisorService(
+            ds4Dir: dir, runner: FakeRunner(),
+            fetchFile: { _, _, _, _, _ in try await Task.sleep(nanoseconds: 600_000_000_000) })
+        s.download(model: .lagunaS21)
+        XCTAssertEqual(s.state, .downloading)
+        XCTAssertEqual(s.download?.file, "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+        s.cancelDownload()
+    }
+    func testCleanupRemovesOnlySameFamilyQuants() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
+        for f in ["ds4-server", "download_model.sh"] {
+            let u = dir.appendingPathComponent(f)
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
+        }
+        let ggufDir = dir.appendingPathComponent("gguf")
+        // Simulate downloaded q2, q4, Pro, and Laguna files on disk.
+        for name in [
+            Quant.q2Imatrix.ggufFilename, Quant.q4Imatrix.ggufFilename,
+            Quant.proImatrix.ggufFilename, Model.lagunaS21.ggufFilename,
+        ] {
+            FileManager.default.createFile(
+                atPath: ggufDir.appendingPathComponent(name).path, contents: Data("gguf".utf8))
+        }
+        let s = SupervisorService(ds4Dir: dir, runner: FakeRunner())
+        let removed = s.cleanupUnusedModels(keep: .v4FlashQ2Q4)
+        XCTAssertTrue(removed.contains(Quant.q2Imatrix.ggufFilename))
+        XCTAssertTrue(removed.contains(Quant.q4Imatrix.ggufFilename))
+        XCTAssertFalse(removed.contains(Quant.proImatrix.ggufFilename))  // Pro always kept
+        XCTAssertFalse(removed.contains(Model.lagunaS21.ggufFilename))  // other family untouched
+        // Cleaning when keeping Laguna is a no-op (single model per family).
+        XCTAssertTrue(s.cleanupUnusedModels(keep: .lagunaS21).isEmpty)
+    }
+>>>>>>> 09f6263 (feat: per-model downloader (Laguna repo) and family-scoped cleanup)
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -330,8 +330,7 @@ final class SupervisorStateMachineTests: XCTestCase {
             at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
         for f in ["ds4-server", "download_model.sh"] {
             let u = dir.appendingPathComponent(f);
-            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
-".utf8))
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
         }
         let gg = dir.appendingPathComponent("gguf").appendingPathComponent(Model.lagunaS21.ggufFilename)
@@ -365,8 +364,7 @@ final class SupervisorStateMachineTests: XCTestCase {
             at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
         for f in ["ds4-server", "download_model.sh"] {
             let u = dir.appendingPathComponent(f)
-            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
-".utf8))
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
         }
         let s = SupervisorService(
@@ -383,8 +381,7 @@ final class SupervisorStateMachineTests: XCTestCase {
             at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
         for f in ["ds4-server", "download_model.sh"] {
             let u = dir.appendingPathComponent(f)
-            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh
-".utf8))
+            FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
         }
         let ggufDir = dir.appendingPathComponent("gguf")

--- a/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+++ b/Tests/DS4ControlTests/SupervisorStateMachineTests.swift
@@ -290,6 +290,40 @@ final class SupervisorStateMachineTests: XCTestCase {
         s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
         if case .error(.modelMissing) = s.state {} else { XCTFail("expected modelMissing, got \(s.state)") }
     }
+    func testStartAddsSsdStreamingArgsWhenEnabled() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(
+            variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertEqual(
+            r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+    }
+    func testStartOmitsSsdStreamingArgsByDefault() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+    }
+    func testStartStreamingWithoutBudgetPassesToggleOnly() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(
+            variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 0)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+    }
+    func testRestartRelaunchCarriesSsdStreamingArgs() throws {
+        let r = FakeRunner(); let s = try makeSupervisor(r)
+        s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+        r.emit("ds4-server: listening on http://127.0.0.1:8000")
+        s.restart(
+            variant: .flash, flashQuant: .q2q4, ctx: 393_216, host: "127.0.0.1", port: 8000,
+            power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+        XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+        XCTAssertEqual(
+            r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+    }
     func testDownloadUsesSelectedQuantFile() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(

--- a/Tests/DS4ControlTests/VariantTests.swift
+++ b/Tests/DS4ControlTests/VariantTests.swift
@@ -68,4 +68,17 @@ final class VariantTests: XCTestCase {
         XCTAssertFalse(flashQuantFits(.q4, ramGiB: 184))
         XCTAssertTrue(flashQuantFits(.q4, ramGiB: 185))
     }
+    func testRoutedExpertGiB() {
+        XCTAssertEqual(Quant.proImatrix.routedExpertGiB, 424, accuracy: 1)  // estimated: 432 − ~8 non-routed
+        XCTAssertEqual(Quant.q4Imatrix.routedExpertGiB, 145, accuracy: 1)  // estimated: 153 − ~8 non-routed
+        XCTAssertEqual(Quant.q2Imatrix.routedExpertGiB, 73, accuracy: 1)  // estimated: 81 − ~8 non-routed
+        XCTAssertEqual(Quant.q2q4Imatrix.routedExpertGiB, 82.69, accuracy: 0.01)  // MEASURED from 0731 GGUF metadata
+    }
+    func testDefaultStreamingCacheGB() {
+        // Truncating budget that leaves ~15 GiB of routed experts to stream from SSD.
+        XCTAssertEqual(Quant.proImatrix.defaultStreamingCacheGB, 409)
+        XCTAssertEqual(Quant.q4Imatrix.defaultStreamingCacheGB, 130)
+        XCTAssertEqual(Quant.q2Imatrix.defaultStreamingCacheGB, 58)
+        XCTAssertEqual(Quant.q2q4Imatrix.defaultStreamingCacheGB, 67)  // 82.69 − 15 = 67.69 → 67
+    }
 }

--- a/docs/superpowers/plans/2026-08-12-laguna-support.md
+++ b/docs/superpowers/plans/2026-08-12-laguna-support.md
@@ -1,0 +1,807 @@
+# Laguna S 2.1 Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let DS4 Control install and serve **Laguna S 2.1 (q2-q3)** alongside DS4F (V4 Pro / V4 Flash), switchable via a unified model picker, targeting 64 GB-class laptops.
+
+**Architecture:** A `Model` enum (family × quant) becomes the app's single model identity, absorbing download metadata, feasibility, ctx, SSD-streaming and thinking-mode capability. `SupervisorService` gains family-aware launch args (SSD streaming gated to DS4F — ds4 hard-refuses it for Laguna; `--prefill-chunk 4096` for Laguna), and the downloader constructs `HFDownloader` per model from its repo. The vendored ds4 submodule moves to a new combined fork branch `ds4-control-patches-v3` (laguna-s2.1 merged into ds4-control-patches-v2 — already built and boot-validated against the real q2-q3 GGUF).
+
+**Tech Stack:** Swift 6, SwiftPM, SwiftUI, XCTest; backing server: vendored `ds4-server` (Metal).
+
+**Design spec:** `docs/superpowers/specs/2026-08-12-laguna-support-design.md` (approved 2026-08-12).
+
+## Global Constraints
+
+- **Worktree:** execute in `/Users/pauleveritt/projects/ds4-control/.worktrees/feat-laguna` on branch `feat/laguna` (forked from `feat/ssd-streaming`). Test from the worktree root.
+- **Build/test are plain now** (Xcode selected + license accepted): `swift build`, `swift test`, `swift format lint --recursive Sources Tests`. No plugin workarounds.
+- **The combined ds4 fork branch already exists** in the worktree's submodule (`external/ds4` on `ds4-control-patches-v3`, HEAD `d0b0caa`), built and smoke-tested. Do not rebuild or re-merge it. The app-side pin moves in Task 8; pushing the branch to the fork (`git push origin ds4-control-patches-v3` from `external/ds4`) may require the user's GitHub auth — if the push fails, note it and continue (the pin still works for local builds; CI/release need the push).
+- **Model facts (measured):** q2-q3 file 44.95 GiB; routed experts 40.87 GiB; non-routed ~4.1; mixed per-layer classes 0.738 (Q2_K) / 0.967 (Q3_K); KV @50k = 2.36 GiB (boot-verified); ctx ceiling 262,144 (GGUF `laguna.context_length`); model id `laguna-s-2.1`; download repo `antirez/Laguna-S-2.1-GGUF`, revision `main`, filename `laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf`.
+- **ds4 hard-gates SSD streaming for Laguna** (`--ssd-streaming is not implemented for Laguna S 2.1 yet` → server refuses to start). The app must never pass it for Laguna.
+- Follow existing patterns exactly (AppState `@Published`+`didSet`; fake-runner arg tests; source-containment view tests in `ChatThinkMaxToggleTests` style).
+- No code changes outside the files listed per task. Stage-1 SSD-streaming behavior for DS4F must remain unchanged.
+
+---
+
+### Task 1: `Model` enum — the single model identity
+
+**Files:**
+- Create: `Sources/DS4Control/Model/Model.swift`
+- Modify: `Tests/DS4ControlTests/VariantTests.swift` (add a `ModelTests` test class in a new file instead: `Tests/DS4ControlTests/ModelTests.swift`)
+
+**Interfaces:**
+- Produces: `enum Model: String, CaseIterable, Identifiable, Codable` with cases `v4Pro, v4FlashQ2, v4FlashQ2Q4, v4FlashQ4, lagunaS21`, plus members listed below. Consumed by every later task. `Quant` (existing DS4F enum) stays as the DS4F table behind `model.quant`.
+
+- [ ] **Step 1: Write the failing tests** — create `Tests/DS4ControlTests/ModelTests.swift`:
+
+```swift
+import XCTest
+@testable import DS4Control
+
+final class ModelTests: XCTestCase {
+    func testAllCasesAndLabels() {
+        XCTAssertEqual(Model.allCases, [.v4Pro, .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4, .lagunaS21])
+        XCTAssertEqual(Model.v4Pro.displayName, "V4 Pro")
+        XCTAssertEqual(Model.v4FlashQ2Q4.displayName, "V4 Flash")
+        XCTAssertEqual(Model.lagunaS21.displayName, "Laguna S 2.1")
+        XCTAssertEqual(Model.v4FlashQ4.label, "V4 Flash · ~153 GiB")
+        XCTAssertEqual(Model.lagunaS21.label, "Laguna S 2.1 · ~45 GiB")
+    }
+    func testModelIds() {
+        XCTAssertEqual(Model.v4Pro.modelId, "deepseek-v4-pro")
+        XCTAssertEqual(Model.v4FlashQ2Q4.modelId, "deepseek-v4-flash")
+        XCTAssertEqual(Model.lagunaS21.modelId, "laguna-s-2.1")
+    }
+    func testQuantMappingAndCapabilities() {
+        XCTAssertEqual(Model.v4FlashQ2Q4.quant, .q2q4Imatrix)
+        XCTAssertNil(Model.lagunaS21.quant)  // no DS4F quant
+        XCTAssertTrue(Model.v4FlashQ2Q4.supportsSSDStreaming)
+        XCTAssertFalse(Model.lagunaS21.supportsSSDStreaming)  // ds4 hard gate
+        XCTAssertTrue(Model.v4FlashQ2Q4.supportsThinkingModes)
+        XCTAssertFalse(Model.lagunaS21.supportsThinkingModes)  // v1: native reasoning, no picker
+    }
+    func testLagunaDownloadAndSizeFacts() {
+        XCTAssertEqual(Model.lagunaS21.weightsGiB, 44.95, accuracy: 0.01)
+        XCTAssertEqual(Model.lagunaS21.downloadRepo, "antirez/Laguna-S-2.1-GGUF")
+        XCTAssertEqual(Model.lagunaS21.downloadRevision, "main")
+        XCTAssertEqual(
+            Model.lagunaS21.ggufFilename,
+            "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+        XCTAssertNil(Model.lagunaS21.routedExpertGiB)  // SSD streaming N/A
+    }
+    func testCtxCeilingAndPrefill() {
+        XCTAssertEqual(Model.lagunaS21.ctxCeiling, 262_144)  // GGUF laguna.context_length
+        XCTAssertEqual(Model.v4FlashQ2Q4.ctxCeiling, 1_000_000)
+        XCTAssertEqual(Model.lagunaS21.defaultPrefillChunk, 4096)
+        XCTAssertNil(Model.v4FlashQ2Q4.defaultPrefillChunk)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter ModelTests`
+Expected: FAIL — `Model` unresolved.
+
+- [ ] **Step 3: Implement** — create `Sources/DS4Control/Model/Model.swift`:
+
+```swift
+import Foundation
+
+/// The runnable models DS4 Control can download and serve. A `Model` fully
+/// determines identity, download metadata, feasibility, and per-model capability
+/// (SSD streaming, thinking modes). DS4F variants map to the existing `Quant`
+/// table; Laguna S 2.1 is its own row (facts measured from the GGUF on disk).
+enum Model: String, CaseIterable, Identifiable, Codable {
+    case v4Pro
+    case v4FlashQ2
+    case v4FlashQ2Q4
+    case v4FlashQ4
+    case lagunaS21
+
+    var id: String { rawValue }
+
+    /// The DS4F quant this model maps to (nil for Laguna — it has no DS4F quant).
+    var quant: Quant? {
+        switch self {
+        case .v4Pro: return .proImatrix
+        case .v4FlashQ2: return .q2Imatrix
+        case .v4FlashQ2Q4: return .q2q4Imatrix
+        case .v4FlashQ4: return .q4Imatrix
+        case .lagunaS21: return nil
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .v4Pro: return "V4 Pro"
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return "V4 Flash"
+        case .lagunaS21: return "Laguna S 2.1"
+        }
+    }
+
+    /// Picker label: display name + resident size, e.g. "V4 Flash · ~91 GiB".
+    var label: String { "\(displayName) · ~\(Int(weightsGiB)) GiB" }
+
+    var modelId: String {
+        switch self {
+        case .v4Pro: return "deepseek-v4-pro"
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return "deepseek-v4-flash"
+        case .lagunaS21: return "laguna-s-2.1"
+        }
+    }
+
+    /// Transformer layers (DS4 shape): Pro 61, Flash 43, Laguna S 48.
+    var layers: Int {
+        switch self {
+        case .v4Pro: return 61
+        case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4: return 43
+        case .lagunaS21: return 48
+        }
+    }
+
+    /// Context ceiling: DS4F 1M; Laguna 262,144 (GGUF `laguna.context_length`).
+    var ctxCeiling: Int {
+        switch self {
+        case .lagunaS21: return 262_144
+        default: return 1_000_000
+        }
+    }
+
+    /// Approx resident weights, GiB (mmap'd GGUF ≈ file size; Laguna measured).
+    var weightsGiB: Double {
+        quant?.weightsGiB ?? 44.95
+    }
+
+    /// Routed-expert bytes for the SSD-streaming budget table; nil for Laguna
+    /// (SSD streaming not supported there).
+    var routedExpertGiB: Double? { quant?.routedExpertGiB }
+
+    var supportsSSDStreaming: Bool { quant != nil }
+    /// v1: thinking-mode picker is DS4F-only (Laguna uses native interleaved reasoning).
+    var supportsThinkingModes: Bool { quant != nil }
+
+    var downloadRepo: String {
+        switch self {
+        case .lagunaS21: return "antirez/Laguna-S-2.1-GGUF"
+        default: return "antirez/deepseek-v4-gguf"
+        }
+    }
+    var downloadRevision: String { "main" }
+    var ggufFilename: String {
+        quant?.ggufFilename ?? "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf"
+    }
+
+    /// Family launch tweak: Laguna bounds graph scratch on 64 GB-class machines
+    /// (measured: prefill 16384 → ~5.9 GiB scratch; 4096 → ~1.5 GiB).
+    var defaultPrefillChunk: Int? { self == .lagunaS21 ? 4096 : nil }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter ModelTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Model/Model.swift Tests/DS4ControlTests/ModelTests.swift
+git commit -m "feat: Model enum — single model identity (DS4F variants + Laguna S 2.1)"
+```
+
+### Task 2: Feasibility + default ctx for Laguna
+
+**Files:**
+- Modify: `Sources/DS4Control/Model/Feasibility.swift`
+- Test: `Tests/DS4ControlTests/FeasibilityTests.swift`
+
+**Interfaces:**
+- Consumes: `Model` (Task 1).
+- Produces: `feasibility(ramGiB:model:)`, `defaultCtx(ramGiB:model:)` — replacing the `variant`/`flashQuant`-typed versions. Old signatures stay temporarily for DS4F callers until Task 7, OR update all callers now — the plan updates the callers in the tasks that own them; this task adds the `Model`-typed overloads and keeps the old ones delegating.
+
+- [ ] **Step 1: Write the failing tests** — append to `FeasibilityTests.swift`:
+
+```swift
+func testLagunaFeasibilityTiers() {
+    XCTAssertEqual(feasibility(ramGiB: 63, model: .lagunaS21), .blocked(reason: "").map(\.reason))  // placeholder
+}
+```
+
+  Replace that placeholder with real assertions (read the file first to match the existing assertion style):
+
+```swift
+func testLagunaFeasibilityTiers() {
+    if case .blocked = feasibility(ramGiB: 63, model: .lagunaS21) {} else { XCTFail("63 GiB must block") }
+    if case .warnWiredLimit = feasibility(ramGiB: 64, model: .lagunaS21) {} else { XCTFail("64 GiB must warn wired limit") }
+    if case .warnWiredLimit = feasibility(ramGiB: 95, model: .lagunaS21) {} else { XCTFail("95 GiB must warn wired limit") }
+    XCTAssertEqual(feasibility(ramGiB: 96, model: .lagunaS21), .standard)
+}
+func testLagunaDefaultCtx() {
+    XCTAssertEqual(defaultCtx(ramGiB: 64, model: .lagunaS21), 50_000)
+    XCTAssertEqual(defaultCtx(ramGiB: 128, model: .lagunaS21), 50_000)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter FeasibilityTests`
+Expected: FAIL — `feasibility(ramGiB:model:)` unresolved.
+
+- [ ] **Step 3: Implement** — in `Feasibility.swift`, add the `Model`-typed overloads (keep the existing `Variant`-typed ones delegating to them):
+
+```swift
+/// Feasibility gate keyed on the runnable model. Laguna S 2.1 (q2-q3, 44.95 GiB
+/// weights) targets 64 GB-class machines: ≥96 GiB is comfortable; 64–95 GiB fits
+/// only with the Metal wired limit raised (default ~0.67×RAM ≈ 43 GiB < weights);
+/// below 64 GiB the weights + 8 GiB OS reserve don't fit.
+func feasibility(ramGiB: Double, model: Model) -> Feasibility {
+    switch model {
+    case .v4Pro:
+        guard ramGiB >= 512 else { return .blocked(reason: "V4 Pro needs ≥ 512 GiB unified memory.") }
+        return .warnWiredLimit(advisoryMB: wiredLimitAdvisoryMB(ramGiB: ramGiB))
+    case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4:
+        if ramGiB >= 128 { return .standard }
+        if ramGiB >= 96 {
+            return .warnWiredLimit(advisoryMB: wiredLimitAdvisoryMB(ramGiB: ramGiB))
+        }
+        return .blocked(
+            reason:
+                "V4 Flash needs ≥ 96 GiB unified memory. Below that, the ~\(Int(model.weightsGiB)) GiB model plus its KV cache exceed RAM, so it can't run."
+        )
+    case .lagunaS21:
+        if ramGiB >= 96 { return .standard }
+        if ramGiB >= 64 {
+            return .warnWiredLimit(advisoryMB: wiredLimitAdvisoryMB(ramGiB: ramGiB))
+        }
+        return .blocked(
+            reason: "Laguna S 2.1 needs ≥ 64 GiB unified memory — its ~45 GiB weights plus the OS reserve don't fit below that."
+        )
+    }
+}
+
+/// Default context keyed on the runnable model. Laguna defaults to 50,000 (SWA-capped
+/// KV is cheap; scratch is bounded by --prefill-chunk 4096); DS4F keeps its tiers.
+func defaultCtx(ramGiB: Double, model: Model) -> Int {
+    switch model {
+    case .lagunaS21: return 50_000
+    case .v4Pro: return model.ctxCeiling
+    case .v4FlashQ2, .v4FlashQ2Q4, .v4FlashQ4:
+        return ramGiB >= 128 ? model.ctxCeiling : thinkMaxMinCtx
+    }
+}
+
+// Keep the existing Variant-typed entry points delegating (removed in Task 7):
+func feasibility(ramGiB: Double, variant: Variant) -> Feasibility {
+    feasibility(ramGiB: ramGiB, model: variant == .pro ? .v4Pro : .v4FlashQ2Q4)
+}
+func defaultCtx(ramGiB: Double, variant: Variant, flashQuant: FlashQuant) -> Int {
+    defaultCtx(ramGiB: ramGiB, model: flashQuant == .q2 ? .v4FlashQ2 : flashQuant == .q4 ? .v4FlashQ4 : .v4FlashQ2Q4)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter FeasibilityTests`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Model/Feasibility.swift Tests/DS4ControlTests/FeasibilityTests.swift
+git commit -m "feat: Laguna feasibility tiers (64 GiB floor, wired-limit band) and 50k default ctx"
+```
+
+### Task 3: `AppState.selectedModel`
+
+**Files:**
+- Modify: `Sources/DS4Control/AppState.swift`
+- Test: `Tests/DS4ControlTests/AppStateTests.swift`
+
+**Interfaces:**
+- Consumes: `Model` (Task 1).
+- Produces: `AppState.selectedModel: Model` (persisted, defaulting by RAM: ≥512 → v4Pro; ≥128 → v4FlashQ2Q4; ≥96 → v4FlashQ2; else lagunaS21), with legacy-key migration from `selectedVariant`/`selectedFlashQuant`. The old `selectedVariant`/`selectedFlashQuant` properties remain (delegating) until Task 7 removes their UI uses — keep them read-only shims here to avoid breaking Task 4–6 call sites.
+
+- [ ] **Step 1: Write the failing tests** — append to `AppStateTests.swift`:
+
+```swift
+func testSelectedModelDefaultsByRAM() {
+    let app = AppState(defaults: UserDefaults(suiteName: "test.\(UUID().uuidString)")!)
+    // On this machine (≥128 GiB) the default is v4FlashQ2Q4, matching the old
+    // defaultFlashQuant behavior. The RAM tiering is covered by the Model-based
+    // feasibility/defaultCtx tests; here we assert the persisted round-trip.
+    XCTAssertEqual(app.selectedModel, .v4FlashQ2Q4)
+}
+func testSelectedModelPersists() {
+    let name = "test.\(UUID().uuidString)"
+    let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+    a1.selectedModel = .lagunaS21
+    let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertEqual(a2.selectedModel, .lagunaS21)
+}
+func testSelectedModelMigratesLegacyVariantKeys() {
+    let d = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+    d.set(Variant.flash.rawValue, forKey: "selectedVariant")
+    d.set(FlashQuant.q2.rawValue, forKey: "selectedFlashQuant")
+    let app = AppState(defaults: d)
+    XCTAssertEqual(app.selectedModel, .v4FlashQ2)  // mapped from the legacy pair
+}
+```
+
+  (Note: `testSelectedModelDefaultsByRAM` asserts `.v4FlashQ2Q4` — correct only on ≥128 GiB machines, matching the existing tests' use of real `systemRamGiB()`. On a 96–127 GiB dev machine it would be `.v4FlashQ2`; keep the machine-RAM-dependent assertion consistent with `testEffectiveCtxFallsBackToDefault`'s pattern.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter AppStateTests`
+Expected: FAIL — `selectedModel` unresolved.
+
+- [ ] **Step 3: Implement** — in `AppState.swift`:
+
+```swift
+/// The runnable model (DS4F variants + Laguna S 2.1). Persisted; the old
+/// selectedVariant/selectedFlashQuant keys migrate into it on first launch.
+@Published var selectedModel: Model { didSet { d.set(selectedModel.rawValue, forKey: "selectedModel") } }
+```
+
+  In `init`, replace the variant/quant read-backs with (keeping the old properties initialized from it for compatibility):
+
+```swift
+let ram = systemRamGiB()
+let storedModel = d.string(forKey: "selectedModel").flatMap(Model.init(rawValue:))
+selectedModel = storedModel ?? migrateLegacySelection(defaults: d, ramGiB: ram)
+```
+
+  Add a private helper (or inline in init, reading only locals per the definite-init rule):
+
+```swift
+private static func migrateLegacySelection(defaults d: UserDefaults, ramGiB: Double) -> Model {
+    if let stored = d.string(forKey: "selectedModel").flatMap(Model.init(rawValue:)) { return stored }
+    if let v = d.string(forKey: "selectedVariant").flatMap(Variant.init(rawValue:)),
+       let f = d.string(forKey: "selectedFlashQuant").flatMap(FlashQuant.init(rawValue:)) {
+        return v == .pro ? .v4Pro : (f == .q2 ? .v4FlashQ2 : f == .q4 ? .v4FlashQ4 : .v4FlashQ2Q4)
+    }
+    return ramGiB >= 512 ? .v4Pro : ramGiB >= 128 ? .v4FlashQ2Q4 : ramGiB >= 96 ? .v4FlashQ2 : .lagunaS21
+}
+```
+
+  Keep `selectedVariant`/`selectedFlashQuant` as read-only computed shims over `selectedModel` (so Tasks 4–6 compile unchanged):
+
+```swift
+var selectedVariant: Variant {
+    get { selectedModel.quant == nil ? .flash : (selectedModel == .v4Pro ? .pro : .flash) }
+    set { selectedModel = newValue == .pro ? .v4Pro : .v4FlashQ2Q4 }
+}
+var selectedFlashQuant: FlashQuant {
+    get { selectedModel.quant == nil ? .q2q4 : (selectedModel.quant == .q4Imatrix ? .q4 : selectedModel.quant == .q2Imatrix ? .q2 : .q2q4) }
+    set { selectedModel = selectedModel == .v4Pro ? .v4Pro : (newValue == .q2 ? .v4FlashQ2 : newValue == .q4 ? .v4FlashQ4 : .v4FlashQ2Q4) }
+}
+```
+
+  (Remove the old `@Published` declarations for the pair — they become computed.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --filter AppStateTests`
+Expected: PASS (existing + 3 new). Then run the FULL suite — the shims must keep every existing test green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/AppState.swift Tests/DS4ControlTests/AppStateTests.swift
+git commit -m "feat: AppState.selectedModel with legacy-key migration and shims"
+```
+
+### Task 4: Family-aware launch args (SSD gating + prefill chunk)
+
+**Files:**
+- Modify: `Sources/DS4Control/Services/SupervisorService.swift`
+- Test: `Tests/DS4ControlTests/SupervisorStateMachineTests.swift`
+
+**Interfaces:**
+- Consumes: `Model` (Task 1), `AppState.selectedModel` (Task 3).
+- Produces: `start(model:ctx:host:port:power:sessions:kvDiskDir:ssdStreaming:ssdStreamingCacheGB:)` and matching `restart(...)` — the `variant`/`flashQuant` params are replaced by `model: Model`. Internal helpers (`ggufURL`, `download`, `isDownloaded`) switch to `model` in Task 5; this task only touches the arg assembly + signatures + the four call sites (ModelRowView ×2, ThinkingModeControls, SettingsView.restart) and the existing tests that call `start(variant:flashQuant:...)` (they switch to `model: .v4FlashQ2Q4` etc.).
+
+- [ ] **Step 1: Write the failing tests** — append to `SupervisorStateMachineTests.swift`:
+
+```swift
+func testLagunaLaunchPassesPrefillChunkAndNeverSsdStreaming() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(model: .lagunaS21, ctx: 50_000, host: "127.0.0.1", port: 8000, power: nil,
+            ssdStreaming: true, ssdStreamingCacheGB: 67)  // global setting ON, must be inert
+    XCTAssertTrue(r.lastArgs.contains("--prefill-chunk"))
+    XCTAssertEqual(r.lastArgs[r.lastArgs.firstIndex(of: "--prefill-chunk")! + 1], "4096")
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+}
+func testDs4fLaunchStillPassesSsdStreamingWhenEnabled() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(model: .v4FlashQ2Q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil,
+            ssdStreaming: true, ssdStreamingCacheGB: 67)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--prefill-chunk"))
+}
+```
+
+  Then update the EXISTING `start`/`restart` calls in this test file (and `SupervisorIntegrationTests.swift` if it calls `start`) from `variant: .flash, flashQuant: .q2q4` to `model: .v4FlashQ2Q4` — mechanical, no assertion changes.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter SupervisorStateMachineTests`
+Expected: FAIL — `start(model:...)` unresolved.
+
+- [ ] **Step 3: Implement** — in `SupervisorService.swift`:
+
+  Change both signatures to `start(model: Model, ctx: Int, ...)` / `restart(model: Model, ...)`. In `start`, replace `let gguf = ggufURL(for: variant, flashQuant: flashQuant)` with `let gguf = ggufURL(for: model)` (helper updated in Task 5; for now add a temporary overload). In the args assembly, replace the Stage-1 SSD block with a capability-gated version and add the prefill chunk:
+
+```swift
+if model.supportsSSDStreaming && ssdStreaming {
+    // SSD-backed expert streaming (DS4F only). ds4 hard-refuses this flag for
+    // Laguna S 2.1, so it is never passed for that model.
+    args += ["--ssd-streaming"]
+    if ssdStreamingCacheGB > 0 {
+        args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+    }
+}
+if let chunk = model.defaultPrefillChunk {
+    // Bounds the graph scratch on 64 GB-class machines (measured: ~1.5 GiB at
+    // 4096 vs ~5.9 GiB at Laguna's default 16384).
+    args += ["--prefill-chunk", "\(chunk)"]
+}
+```
+
+  Add a temporary `ggufURL(for model: Model)` overload (Task 5 replaces it):
+
+```swift
+private func ggufURL(for model: Model) -> URL {
+    ggufBaseDir().appendingPathComponent(model.ggufFilename)
+}
+```
+
+  Update the four call sites (`ModelRowView` ×2, `ThinkingModeControls`, `SettingsView.restart`) to `model: app.selectedModel` and drop the `flashQuant:` argument.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test` (full suite — all `start(...)` callers updated).
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Services/SupervisorService.swift Sources/DS4Control/Views/ModelRowView.swift Sources/DS4Control/Views/ThinkingModeControls.swift Sources/DS4Control/Views/SettingsView.swift Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+git commit -m "feat: family-aware launch args — SSD streaming DS4F-only, prefill-chunk for Laguna"
+```
+
+### Task 5: Per-model downloader + family-scoped cleanup
+
+**Files:**
+- Modify: `Sources/DS4Control/Services/SupervisorService.swift`, `Sources/DS4Control/Model/Variant.swift`
+- Test: `Tests/DS4ControlTests/SupervisorStateMachineTests.swift`, `Tests/DS4ControlTests/HFDownloaderTests.swift`
+
+**Interfaces:**
+- Consumes: `Model.downloadRepo/downloadRevision/ggufFilename` (Task 1).
+- Produces: `download(model:highPerformance:)`, `isDownloaded(_ model:)`, `cleanupUnusedModels(keep:)`, `isModelDownloaded(_:)`; `ggufURL(for model:)` (real impl); the `ggufRepo` static is removed. Old `variant`/`flashQuant`-typed download entry points are removed (callers updated in Task 4/7).
+
+- [ ] **Step 1: Write the failing tests** — append to `SupervisorStateMachineTests.swift`:
+
+```swift
+func testLagunaDownloadUsesLagunaFile() throws {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: dir.appendingPathComponent("gguf"), withIntermediateDirectories: true)
+    for f in ["ds4-server", "download_model.sh"] {
+        let u = dir.appendingPathComponent(f)
+        FileManager.default.createFile(atPath: u.path, contents: Data("#!/bin/sh\n".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: u.path)
+    }
+    let s = SupervisorService(
+        ds4Dir: dir, runner: FakeRunner(),
+        fetchFile: { _, _, _, _, _ in try await Task.sleep(nanoseconds: 600_000_000_000) })
+    s.download(model: .lagunaS21)
+    XCTAssertEqual(s.state, .downloading)
+    XCTAssertEqual(s.download?.file, "laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+    s.cancelDownload()
+}
+func testCleanupRemovesOnlySameFamilyQuants() throws {
+    let s = try makeSupervisor(runDownloadedQuants: true)  // see note below
+    let removed = s.cleanupUnusedModels(keep: .v4FlashQ2Q4)
+    XCTAssertTrue(removed.contains(Quant.q2Imatrix.ggufFilename))
+    XCTAssertFalse(removed.contains(Quant.proImatrix.ggufFilename))  // Pro always kept
+    XCTAssertFalse(removed.contains("laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf"))  // other family untouched
+}
+```
+
+  (Adapt `testCleanupRemovesOnlySameFamilyQuants` to the existing test fixtures: create the ds4 dir + fake gguf files for `.q2Imatrix`, `.q4Imatrix`, `.proImatrix`, and the Laguna filename, then assert only the non-kept Flash quants are removed. If the file lacks a helper, inline the fixture like `testMissingModel` does.)
+
+  In `HFDownloaderTests.swift`, add a test asserting the fetch URL uses the Laguna repo:
+
+```swift
+func testLagunaRepoResolveURL() throws {
+    let d = HFDownloader(repo: "antirez/Laguna-S-2.1-GGUF")
+    // Construct the URL the way the implementation does and assert the path.
+    let url = URL(string: "https://huggingface.co/antirez/Laguna-S-2.1-GGUF/resolve/main/laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")!
+    XCTAssertEqual(url.path, "/antirez/Laguna-S-2.1-GGUF/resolve/main/laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter SupervisorStateMachineTests` and `--filter HFDownloaderTests`
+Expected: FAIL — `download(model:)` / `cleanupUnusedModels` unresolved.
+
+- [ ] **Step 3: Implement** — in `SupervisorService.swift`:
+
+  - Remove `private static let ggufRepo = "antirez/deepseek-v4-gguf"`; the fetch closure becomes per-model at call time. Change the `download` implementation to construct the downloader from the model:
+
+```swift
+let fetch = fetchFile
+downloadTask = Task { [weak self] in
+    do {
+        try await fetch(filename, baseDir, token, highPerformance) { received, total in
+            Self.onMain { self?.updateDownloadProgress(gen: gen, file: filename, received: received, total: total) }
+        }
+        ...
+```
+  becomes the model-parameterized version — replace the closure body's `HFDownloader(repo: SupervisorService.ggufRepo)` construction with a per-model `HFDownloader(repo: model.downloadRepo, revision: model.downloadRevision)`. Concretely, the default `fetchFile` in `init` stays (it receives `file` + destDir); move the repo/revision selection into a new `fetchFile` default that reads the model at the call site. Simplest: build the downloader inline in `download(model:)` and drop the injected-closure default indirection — but keep `fetchFile` injectable for tests by changing its signature to `(Model, URL, String?, Bool, @escaping (Int64, Int64) -> Void)`. Update the test fakes accordingly.
+
+  - `ggufURL(for model: Model)` (replace the temporary): `ggufBaseDir().appendingPathComponent(model.ggufFilename)`.
+  - `isDownloaded(_ model: Model) -> Bool` (rename/overload `isDownloaded(_:flashQuant:)`).
+  - `isModelDownloaded(_ model: Model) -> Bool` for the Settings markers (generalizes `isFlashQuantDownloaded`).
+  - `cleanupUnusedModels(keep: Model) -> [String]` — generalizes `cleanupUnusedFlashQuants`: if `keep.quant` is nil (Laguna) return `[]` (single model per family); else remove downloaded Flash quants `!= keep.quant`, never Pro, never the Laguna file:
+
+```swift
+@discardableResult
+func cleanupUnusedModels(keep: Model) -> [String] {
+    guard let keepQuant = keep.quant else { return [] }  // Laguna: nothing to clean
+    var removed: [String] = []
+    for q in FlashQuant.allCases {
+        let qq = q.quant
+        if qq == keepQuant { continue }
+        let url = flashQuantURL(q)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
+            removed.append(qq.ggufFilename)
+        }
+    }
+    ggufStoreVersion += 1
+    return removed
+}
+```
+
+  - Update `SettingsView`'s cleanup call site and `removableFlashQuants` to the `Model`-based API (or defer to Task 7's UI task — the plan prefers deferring the UI churn; keep the old `cleanupUnusedFlashQuants` as a wrapper calling `cleanupUnusedModels(keep: .v4FlashQ2Q4)` if call sites remain).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test`
+Expected: PASS (full suite; test fakes updated for the new fetch signature).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Services/SupervisorService.swift Sources/DS4Control/Model/Variant.swift Tests/DS4ControlTests/SupervisorStateMachineTests.swift Tests/DS4ControlTests/HFDownloaderTests.swift
+git commit -m "feat: per-model downloader (Laguna repo) and family-scoped cleanup"
+```
+
+### Task 6: Chat gating + agent launcher family awareness
+
+**Files:**
+- Modify: `Sources/DS4Control/DS4ControlApp.swift`, `Sources/DS4Control/Services/AgentLauncher.swift`, `Sources/DS4Control/Views/ThinkingModeControls.swift`
+- Test: `Tests/DS4ControlTests/AgentLauncherTests.swift`, `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift`
+
+**Interfaces:**
+- Consumes: `Model.supportsThinkingModes/modelId` (Task 1), `AppState.selectedModel` (Task 3).
+- Produces: thinking-picker gating by model; `AgentLauncher.modelId(for:fallback:)` over `Model`; `knownModelIds` includes `laguna-s-2.1`; the pi `models.json` gains the Laguna model entry.
+
+- [ ] **Step 1: Write the failing tests** — append to `AgentLauncherTests.swift` (read the file first for the existing fixture pattern):
+
+```swift
+func testKnownModelIdsIncludesLaguna() {
+    XCTAssertTrue(AgentLauncher.knownModelIds.contains("laguna-s-2.1"))
+}
+func testModelIdFallbackAcceptsModel() {
+    XCTAssertEqual(AgentLauncher.modelId(for: nil, fallback: .lagunaS21), "laguna-s-2.1")
+    XCTAssertEqual(AgentLauncher.modelId(for: "deepseek-v4-flash", fallback: .lagunaS21), "deepseek-v4-flash")
+}
+func testPiModelsJSONHasLagunaEntry() throws {
+    let json = AgentLauncher.piModelsJSON(port: 8000, contextWindow: 50_000)
+    XCTAssertTrue(json.contains("\"id\": \"laguna-s-2.1\""))
+}
+```
+
+  Append to `ChatThinkMaxToggleTests.swift`:
+
+```swift
+func testThinkingPickerHiddenForLaguna() throws {
+    let picker = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+    XCTAssertTrue(picker.contains("supportsThinkingModes"))
+    XCTAssertTrue(picker.contains("selectedModel"))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter AgentLauncherTests` and `--filter ChatThinkMaxToggleTests`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**:
+
+  - `AgentLauncher.swift`: `static let knownModelIds = ["deepseek-v4-pro", "deepseek-v4-flash", "laguna-s-2.1"]`; change `modelId(for activeModel: String?, fallback: Model)` (update the PopupView call site in Task 7 or here — the popup call passes `app.selectedVariant`; update to `app.selectedModel`). Add a Laguna model entry to `piModelsJSON`:
+
+```swift
+{
+  "id": "laguna-s-2.1",
+  "name": "Laguna S 2.1 (ds4.c local)",
+  "reasoning": true,
+  "thinkingLevelMap": \(levelMap),
+  "input": ["text"],
+  "contextWindow": \(contextWindow),
+  "maxTokens": 262144,
+  "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+}
+```
+
+  (The `supportsReasoningEffort`/`thinkingFormat` compat flags stay as-is for v1 — verify against a live server in Task 9's SSE smoke test; the user's working pi config reaches Laguna, so the generated entry mirrors the DS4F shape.)
+
+  - `ThinkingModeControls.swift`: gate the picker + the `confirmAndApply` path on `app.selectedModel.supportsThinkingModes` (when false, render `EmptyView` and skip the alert).
+  - `DS4ControlApp.swift`: `ChatViewModel(model: app.selectedModel.modelId, ...)`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/DS4ControlApp.swift Sources/DS4Control/Services/AgentLauncher.swift Sources/DS4Control/Views/ThinkingModeControls.swift Tests/DS4ControlTests/AgentLauncherTests.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: family-aware chat thinking gating and agent launcher (Laguna entry)"
+```
+
+### Task 7: Unified model picker UI
+
+**Files:**
+- Modify: `Sources/DS4Control/Views/ModelRowView.swift`, `Sources/DS4Control/Views/SettingsView.swift`, `Sources/DS4Control/Views/PopupView.swift`
+- Test: `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift` (source tests)
+
+**Interfaces:**
+- Consumes: `Model.allCases`, `feasibility(ramGiB:model:)`, `supervisor.isModelDownloaded(_:)` (Tasks 1–5).
+- Produces: the unified picker (feasible models only) in the popup row; Settings "Model" section (replacing "V4 Flash model"), SSD-streaming N/A state for Laguna, cleanup via `cleanupUnusedModels`; dead DS4F-only code removed (`Variant`-typed feasibility shims, `selectedVariant`/`selectedFlashQuant` shims in AppState).
+
+- [ ] **Step 1: Write the failing source tests** — append to `ChatThinkMaxToggleTests.swift`:
+
+```swift
+func testModelRowPickerUsesModelCases() throws {
+    let row = try source("Sources/DS4Control/Views/ModelRowView.swift")
+    XCTAssertTrue(row.contains("Model.allCases"))
+    XCTAssertTrue(row.contains("selectedModel"))
+    XCTAssertTrue(row.contains("feasibility(ramGiB: ramGiB, model:"))
+}
+func testSettingsHasLagunaModelSectionAndSsdNA() throws {
+    let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+    XCTAssertTrue(settings.contains("supportsSSDStreaming"))
+    XCTAssertTrue(settings.contains("Laguna S 2.1"))
+    XCTAssertTrue(settings.contains("cleanupUnusedModels"))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --filter ChatThinkMaxToggleTests`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**:
+
+  - `ModelRowView.swift`: replace the `variants` picker with a `Model.allCases` picker filtered by feasibility, and drive `app.selectedModel`:
+
+```swift
+private var runnableModels: [Model] {
+    Model.allCases.filter { feasibility(ramGiB: ramGiB, model: $0) != .blocked(reason: "") && feasibility(ramGiB: ramGiB, model: $0) != .blocked(reason: "") }
+}
+```
+
+  (Write it cleanly: `Model.allCases.filter { if case .blocked = feasibility(ramGiB: ramGiB, model: $0) { return false }; return true }`.) The `actionButton`/`feasibilityNote` switch to `app.selectedModel` and `isModelDownloaded(_:)`; the wired-limit note text branches per model (Laguna 64–95 GiB wording; DS4F existing wording). `supervisor.start(model: app.selectedModel, ...)`.
+
+  - `SettingsView.swift`: rename the "V4 Flash model" section to "Model"; the quant picker becomes a `Picker` over `Model.allCases` (feasible only, same `.disabled(downloading)`); cleanup button calls `cleanupUnusedModels(keep: app.selectedModel)` with per-family copy; the SSD-streaming section shows the toggle disabled with an "N/A for Laguna S 2.1" caption when `!app.selectedModel.supportsSSDStreaming`, and the budget slider is hidden then. The streaming caption/range use `app.selectedModel.quant?.routedExpertGiB` (nil for Laguna → hidden).
+  - `PopupView.swift`: the agent-launch call uses `app.selectedModel` (via the updated `AgentLauncher.modelId`); the chat gating is handled by thinking-mode gating.
+  - `AppState.swift`: remove the `selectedVariant`/`selectedFlashQuant` computed shims and their remaining callers; `Feasibility.swift`: remove the `Variant`-typed delegating overloads.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test` (full suite) + `swift format lint --recursive Sources Tests`
+Expected: PASS, lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Views/ModelRowView.swift Sources/DS4Control/Views/SettingsView.swift Sources/DS4Control/Views/PopupView.swift Sources/DS4Control/AppState.swift Sources/DS4Control/Model/Feasibility.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: unified model picker; SSD-streaming N/A and thinking gating for Laguna"
+```
+
+### Task 8: Submodule pin to `ds4-control-patches-v3`
+
+**Files:**
+- `external/ds4` (gitlink), `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the combined fork branch (already checked out in the worktree's submodule at `d0b0caa`).
+- Produces: the app repo's submodule pointer moved to `ds4-control-patches-v3`; the branch pushed to the fork (auth permitting).
+
+- [ ] **Step 1: Push the fork branch (auth permitting)**
+
+```bash
+cd external/ds4
+git push origin ds4-control-patches-v3
+```
+
+  If auth fails: record it in the commit message / CHANGELOG note and continue — the pin is valid locally; CI needs the push before merging.
+
+- [ ] **Step 2: Move the pin**
+
+```bash
+cd /Users/pauleveritt/projects/ds4-control/.worktrees/feat-laguna
+git add external/ds4
+git status --short   # expect: modified external/ds4
+```
+
+- [ ] **Step 3: CHANGELOG + commit**
+
+  Add under Unreleased:
+
+```markdown
+- ds4 submodule moved to `ds4-control-patches-v3`: `laguna-s2.1` merged into `ds4-control-patches-v2` (15 conflict files resolved), adding native **Laguna S 2.1** support alongside DeepSeek V4/GLM. THINK_MAX 0731 prefix and DSpark/Metal work retained. Boot-verified against the q2-q3 GGUF.
+```
+
+```bash
+git commit -m "chore: pin ds4 submodule to ds4-control-patches-v3 (Laguna support)"
+```
+
+### Task 9: Full verification + changelog
+
+**Files:**
+- Modify: `CHANGELOG.md` (Laguna feature entry)
+
+**Interfaces:**
+- Consumes: everything.
+
+- [ ] **Step 1: Full test suite + lint**
+
+Run: `swift test` and `swift format lint --recursive Sources Tests`
+Expected: all green, lint clean.
+
+- [ ] **Step 2: Release build + .app**
+
+Run: `swift build -c release -Xswiftc -warnings-as-errors` then `DS4_SRC="$PWD/external/ds4" bash build.sh`
+Expected: clean build; `DS4 Control.app` with the Laguna-capable bundled ds4-server.
+
+- [ ] **Step 3: Live boot (real model)**
+
+Kill any running ds4 first. Launch via the app's exact arg path with the Laguna model (from `/Users/pauleveritt/projects/ds4/gguf/`), `--prefill-chunk 4096`, no `--ssd-streaming`:
+- KV/scratch report shows the bounded scratch
+- `/v1/models` reports `laguna-s-2.1`, ctx 50000
+- One greedy completion works
+
+- [ ] **Step 4: SSE smoke test (chat shape)**
+
+Point the built-in chat at the running server (or curl) with `"stream": true`; confirm `reasoning_content` vs `content` split renders sensibly in the thinking section; adjust the thinking-gating or compat flags in Task 6 if the shape differs from DS4F.
+
+- [ ] **Step 5: Negative checks**
+
+- Selecting Laguna never passes `--ssd-streaming` (asserted in Task 4 tests; also visually: Settings shows N/A)
+- The 64–95 GiB wired-limit advisory shows for Laguna on a 64 GB-class machine (feasibility unit-tested)
+- The DS4F SSD-streaming behavior is unchanged (Stage-1 tests + one DS4F boot, optional)
+
+- [ ] **Step 6: CHANGELOG + commit**
+
+```markdown
+- **Laguna S 2.1 (q2-q3) support:** new model in the picker — download, start, serve, chat (basic), agents. 64 GiB feasibility floor, 50k default context, `--prefill-chunk 4096`. SSD streaming stays DS4F-only (ds4 hard gate). No DFlash (deferred).
+```
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog — Laguna S 2.1 support"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every spec decision maps to a task — Model abstraction (T1), feasibility/ctx (T2), AppState (T3), SSD gating + prefill (T4), downloader/cleanup (T5), chat/agents (T6), unified picker + N/A states (T7), submodule pin (T8), verification incl. live boot + SSE smoke test + negative checks (T9). Out-of-scope items (q4, DFlash, Laguna SSD streaming, gate relaxation) are absent.
+- **Placeholder scan:** no TBD; the two intentionally-fuzzy spots are flagged with explicit resolutions (`testCleanupRemovesOnlySameFamilyQuants` fixture note; `piModelsJSON` compat flags verified in T9). The `runnableModels` filter is spelled out in prose after the sketch.
+- **Type consistency:** `Model` cases and members (`.quant`, `.supportsSSDStreaming`, `.supportsThinkingModes`, `.downloadRepo`, `.defaultPrefillChunk`, `.ctxCeiling` = 262_144, `.weightsGiB` = 44.95) are identical across T1–T7; `start(model:...)`/`download(model:)`/`cleanupUnusedModels(keep:)` signatures are stable from first use.

--- a/docs/superpowers/plans/2026-08-12-ssd-streaming.md
+++ b/docs/superpowers/plans/2026-08-12-ssd-streaming.md
@@ -1,0 +1,501 @@
+# SSD Streaming Implementation Plan (Staged)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stage 1 — ship SSD streaming for `ds4-server` in DS4 Control, default ON with an expert-cache budget that frees ~15 GiB of resident model weights (moved to SSD), exposed as a Settings toggle + slider. Stage 2 (captured, not scheduled) — multi-model support for Laguna S 2.1.
+
+**Architecture:** `ds4-server` already supports `--ssd-streaming` with an explicit `--ssd-streaming-cache-experts NGB` budget (measured model facts in the design spec: q2-q4 0731 has 82.7 GiB of routed expert weights; a 67 GB cache budget frees ~15.7 GiB; ds4's startup log reports the actual cache). The app changes are additive: a per-quant expert-size table on `Quant` (`Model/Variant.swift`), two persisted AppState settings, two defaulted params on `SupervisorService.start()/restart()`, and a new Settings section — all following existing patterns.
+
+**Tech Stack:** Swift 6, SwiftPM, SwiftUI, XCTest. Backing server: vendored `ds4-server` (Metal backend).
+
+**Design spec:** `docs/superpowers/specs/2026-08-12-ssd-streaming-design.md` (approved 2026-08-12).
+
+## Global Constraints
+
+- **Build/test commands need the SwiftUIMacros plugin workaround** on this machine: `xcode-select` points at CommandLineTools (no `libSwiftUIMacros.dylib`) and Xcode's license is unaccepted. Every `swift build` / `swift test` in this plan must use:
+
+  ```bash
+  export SWIFTUI_PLUGIN="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins/libSwiftUIMacros.dylib"
+  swift build -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"
+  swift test  -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"
+  ```
+
+  (CI on `macos-26` needs no workaround. Permanent local fix: `sudo xcode-select -s /Applications/Xcode.app` + `sudo xcodebuild -license accept`, then plain commands work.)
+- Repo root: `/Users/pauleveritt/projects/ds4-control`. Run tests from there.
+- **Follow existing patterns exactly:** AppState settings are `@Published var X { didSet { d.set(X, forKey:) } }` with read-back in `init`; SupervisorService arg tests use the file-private `FakeRunner` in `SupervisorStateMachineTests.swift`; view presence is asserted via source-containment tests (see `ChatThinkMaxToggleTests.source(_:)`).
+- CI runs `swift format lint --strict --recursive Sources Tests` — keep formatting clean (run `swift format lint --recursive Sources Tests` before committing; the project uses `.swift-format`).
+- No code changes outside the files listed per task. No Laguna work in Stage 1.
+- All test-file changes are additive; existing tests must keep passing.
+
+---
+
+## Stage 1 — SSD Streaming (the "no-Laguna" build)
+
+### Task 1: Per-quant routed-expert table + default budget
+
+**Files:**
+- Modify: `Sources/DS4Control/Model/Variant.swift` (add two members to `Quant`)
+- Test: `Tests/DS4ControlTests/VariantTests.swift`
+
+**Interfaces:**
+- Produces: `Quant.routedExpertGiB: Double` and `Quant.defaultStreamingCacheGB: Int` (truncating `Int(routedExpertGiB - 15)`, floor 16). Consumed by Tasks 2 and 5.
+
+- [ ] **Step 1: Write the failing tests** — append to `VariantTests.swift`:
+
+```swift
+func testRoutedExpertGiB() {
+    XCTAssertEqual(Quant.proImatrix.routedExpertGiB, 424, accuracy: 1)  // estimated: 432 − ~8 non-routed
+    XCTAssertEqual(Quant.q4Imatrix.routedExpertGiB, 145, accuracy: 1)  // estimated: 153 − ~8 non-routed
+    XCTAssertEqual(Quant.q2Imatrix.routedExpertGiB, 73, accuracy: 1)  // estimated: 81 − ~8 non-routed
+    XCTAssertEqual(Quant.q2q4Imatrix.routedExpertGiB, 82.69, accuracy: 0.01)  // MEASURED from 0731 GGUF metadata
+}
+func testDefaultStreamingCacheGB() {
+    // Truncating budget that leaves ~15 GiB of routed experts to stream from SSD.
+    XCTAssertEqual(Quant.proImatrix.defaultStreamingCacheGB, 409)
+    XCTAssertEqual(Quant.q4Imatrix.defaultStreamingCacheGB, 130)
+    XCTAssertEqual(Quant.q2Imatrix.defaultStreamingCacheGB, 58)
+    XCTAssertEqual(Quant.q2q4Imatrix.defaultStreamingCacheGB, 67)  // 82.69 − 15 = 67.69 → 67
+}
+```
+
+  (The floor of 16 GiB in `defaultStreamingCacheGB` is defensive only — every real quant is ≥ 73 GiB — so it is not separately unit-tested.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc -load-plugin-library "$SWIFTUI_PLUGIN" --filter VariantTests` (with `SWIFTUI_PLUGIN` exported per Global Constraints)
+Expected: FAIL — `routedExpertGiB`/`defaultStreamingCacheGB` unresolved.
+
+- [ ] **Step 3: Implement** — in `Variant.swift`, inside `enum Quant` (after `weightsGiB`):
+
+```swift
+/// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to disk.
+/// q2-q4 measured from the 0731 GGUF metadata (ffn gate/up/down expert tensors);
+/// the others are estimated as total weights minus ~8 GiB non-routed
+/// (attention, embeddings, shared FFN, norms).
+var routedExpertGiB: Double {
+    switch self {
+    case .proImatrix: return 424
+    case .q4Imatrix: return 145
+    case .q2Imatrix: return 73
+    case .q2q4Imatrix: return 82.69
+    }
+}
+
+/// Default SSD-streaming expert-cache budget (GiB) for this quant: keeps all but
+/// ~15 GiB of routed experts resident; the rest stream from the GGUF on demand.
+/// Truncates (82.69 − 15 → 67). Floor 16 so a degenerate tiny cache can never be
+/// configured accidentally.
+var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter VariantTests`
+Expected: PASS (6 tests, existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Model/Variant.swift Tests/DS4ControlTests/VariantTests.swift
+git commit -m "feat: per-quant routed-expert table for SSD streaming defaults"
+```
+
+### Task 2: AppState settings (default ON, 15 GiB-free budget)
+
+**Files:**
+- Modify: `Sources/DS4Control/AppState.swift`
+- Test: `Tests/DS4ControlTests/AppStateTests.swift`
+
+**Interfaces:**
+- Consumes: `Quant.routedExpertGiB` / `Quant.defaultStreamingCacheGB` (Task 1).
+- Produces: `AppState.ssdStreaming: Bool` (default `true`) and `AppState.ssdStreamingCacheGB: Int` (default = `Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB`). Consumed by Tasks 3–5.
+
+- [ ] **Step 1: Write the failing tests** — append to `AppStateTests.swift`:
+
+```swift
+func testSsdStreamingDefaultsOnAndPersists() {
+    let name = "test.\(UUID().uuidString)"
+    let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertTrue(a1.ssdStreaming)  // default ON — frees ~15 GiB on fresh installs
+    a1.ssdStreaming = false
+    let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertFalse(a2.ssdStreaming)  // persisted
+}
+func testSsdStreamingCacheGBDefaultsToFree15BudgetAndPersists() {
+    let name = "test.\(UUID().uuidString)"
+    let a1 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertEqual(
+        a1.ssdStreamingCacheGB,
+        Quant.for(a1.selectedVariant, flashQuant: a1.selectedFlashQuant).defaultStreamingCacheGB)
+    a1.ssdStreamingCacheGB = 80
+    let a2 = AppState(defaults: UserDefaults(suiteName: name)!)
+    XCTAssertEqual(a2.ssdStreamingCacheGB, 80)  // persisted, not re-defaulted
+}
+```
+
+  (The default-then-uses-machine-RAM assertion matches the existing `testEffectiveCtxFallsBackToDefault` pattern; the exact `67` for q2-q4 is asserted in Task 1.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter AppStateTests`
+Expected: FAIL — `ssdStreaming`/`ssdStreamingCacheGB` unresolved.
+
+- [ ] **Step 3: Implement** — in `AppState.swift`, add properties alongside the other `@Published` settings (after `kvDiskCache`):
+
+```swift
+/// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM; the
+/// rest stream from the GGUF on demand. Default ON with the ~15 GiB-free budget
+/// for the selected quant.
+@Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+@Published var ssdStreamingCacheGB: Int {
+    didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+}
+```
+
+  In `init`, after the `selectedVariant`/`selectedFlashQuant` read-backs (so the default can key off them):
+
+```swift
+ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true  // default on
+let storedGB = d.object(forKey: "ssdStreamingCacheGB") as? Int
+ssdStreamingCacheGB =
+    storedGB ?? Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter AppStateTests`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/AppState.swift Tests/DS4ControlTests/AppStateTests.swift
+git commit -m "feat: SSD streaming AppState settings, default ON with ~15 GiB-free budget"
+```
+
+### Task 3: SupervisorService launch args
+
+**Files:**
+- Modify: `Sources/DS4Control/Services/SupervisorService.swift` (`start(...)` and `restart(...)`)
+- Test: `Tests/DS4ControlTests/SupervisorStateMachineTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new (raw `Bool`/`Int` params from callers).
+- Produces: `SupervisorService.start(variant:flashQuant:ctx:host:port:power:sessions:kvDiskDir:ssdStreaming:ssdStreamingCacheGB:)` and the matching `restart(...)` — both with `ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0` appended as defaulted params (existing callers keep compiling). Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing tests** — append to `SupervisorStateMachineTests.swift`:
+
+```swift
+func testStartAddsSsdStreamingArgsWhenEnabled() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(
+        variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertEqual(
+        r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+}
+func testStartOmitsSsdStreamingArgsByDefault() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+}
+func testStartStreamingWithoutBudgetPassesToggleOnly() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(
+        variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 0)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertFalse(r.lastArgs.contains("--ssd-streaming-cache-experts"))
+}
+func testRestartRelaunchCarriesSsdStreamingArgs() throws {
+    let r = FakeRunner(); let s = try makeSupervisor(r)
+    s.start(variant: .flash, flashQuant: .q2q4, ctx: 250_000, host: "127.0.0.1", port: 8000, power: nil)
+    r.emit("ds4-server: listening on http://127.0.0.1:8000")
+    s.restart(
+        variant: .flash, flashQuant: .q2q4, ctx: 393_216, host: "127.0.0.1", port: 8000,
+        power: nil, ssdStreaming: true, ssdStreamingCacheGB: 67)
+    XCTAssertTrue(r.lastArgs.contains("--ssd-streaming"))
+    XCTAssertEqual(
+        r.lastArgs[r.lastArgs.firstIndex(of: "--ssd-streaming-cache-experts")! + 1], "67GB")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter SupervisorStateMachineTests`
+Expected: FAIL — `ssdStreaming`/`ssdStreamingCacheGB` are extra arguments.
+
+- [ ] **Step 3: Implement** — in `SupervisorService.swift`, extend both signatures:
+
+```swift
+func start(
+    variant: Variant,
+    flashQuant: FlashQuant,
+    ctx: Int,
+    host: String,
+    port: Int,
+    power: Int?,
+    sessions: Int = 1,
+    kvDiskDir: URL? = nil,
+    ssdStreaming: Bool = false,
+    ssdStreamingCacheGB: Int = 0
+)
+```
+
+  and the identical param list on `restart(...)`. In `start`, right after the `--metal` line in the args assembly (before the `if let power` block):
+
+```swift
+if ssdStreaming {
+    // SSD-backed expert streaming: only `ssdStreamingCacheGB` of routed experts
+    // stay resident; the rest load from the GGUF on cache miss. 0 omits the
+    // budget so ds4 picks its automatic cache.
+    args += ["--ssd-streaming"]
+    if ssdStreamingCacheGB > 0 {
+        args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+    }
+}
+```
+
+  In `restart`, forward the two values into the `start(...)` call inside the `relaunch` closure.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter SupervisorStateMachineTests`
+Expected: PASS (existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Services/SupervisorService.swift Tests/DS4ControlTests/SupervisorStateMachineTests.swift
+git commit -m "feat: pass --ssd-streaming and expert-cache budget to ds4-server"
+```
+
+### Task 4: Thread the setting through the four call sites
+
+**Files:**
+- Modify: `Sources/DS4Control/Views/ModelRowView.swift` (two `supervisor.start(...)` calls), `Sources/DS4Control/Views/ThinkingModeControls.swift` (one `supervisor.restart(...)` call), `Sources/DS4Control/Views/SettingsView.swift` (the `restart()` helper)
+- Test: `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift` (source-containment additions)
+
+**Interfaces:**
+- Consumes: `app.ssdStreaming`, `app.ssdStreamingCacheGB` (Task 2) and the Task 3 signatures.
+- Produces: all launch/restart paths carrying the setting.
+
+- [ ] **Step 1: Write the failing source tests** — append to `ChatThinkMaxToggleTests.swift` (the class already has the private `source(_:)` helper):
+
+```swift
+func testModelRowStartThreadsSsdStreamingSetting() throws {
+    let modelRow = try source("Sources/DS4Control/Views/ModelRowView.swift")
+    XCTAssertEqual(
+        modelRow.components(separatedBy: "supervisor.start(").count - 1, 2,
+        "both start call sites must pass the setting")
+    // Both call sites use identical trailing args; assert the pattern appears twice.
+    let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+    XCTAssertEqual(modelRow.components(separatedBy: pattern).count - 1, 2)
+}
+func testRestartCallSitesThreadSsdStreamingSetting() throws {
+    let thinking = try source("Sources/DS4Control/Views/ThinkingModeControls.swift")
+    let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+    let pattern = "ssdStreaming: app.ssdStreaming, ssdStreamingCacheGB: app.ssdStreamingCacheGB"
+    XCTAssertTrue(thinking.contains(pattern))
+    XCTAssertTrue(settings.contains(pattern))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter ChatThinkMaxToggleTests`
+Expected: FAIL — pattern not found.
+
+- [ ] **Step 3: Implement** — at each call site, after the existing `kvDiskDir:` argument, add:
+
+```swift
+ssdStreaming: app.ssdStreaming,
+ssdStreamingCacheGB: app.ssdStreamingCacheGB,
+```
+
+  In `ModelRowView.swift` both `supervisor.start(...)` calls get it (they are inside the `.error` retry branch and the `default` Start branch). In `ThinkingModeControls.confirmAndApply` and `SettingsView.restart()` the `supervisor.restart(...)` calls get it.
+
+- [ ] **Step 4: Verify** — run the full test suite (build + tests with the plugin flag), expected all green; run `swift format lint --recursive Sources Tests` to confirm no lint drift.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Views/ModelRowView.swift Sources/DS4Control/Views/ThinkingModeControls.swift Sources/DS4Control/Views/SettingsView.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: thread SSD streaming setting through all start/restart call sites"
+```
+
+### Task 5: Settings UI section
+
+**Files:**
+- Modify: `Sources/DS4Control/Views/SettingsView.swift`
+- Test: `Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift`
+
+**Interfaces:**
+- Consumes: `AppState.ssdStreaming`, `AppState.ssdStreamingCacheGB` (Task 2), `Quant.routedExpertGiB` + existing `Quant.for(_:flashQuant:)` (Task 1).
+- Produces: the "SSD streaming" Settings section (toggle + budget slider + freed-RAM caption).
+
+- [ ] **Step 1: Write the failing source test** — append to `ChatThinkMaxToggleTests.swift`:
+
+```swift
+func testSettingsHasSsdStreamingSection() throws {
+    let settings = try source("Sources/DS4Control/Views/SettingsView.swift")
+    XCTAssertTrue(settings.contains(#""Stream expert weights from SSD""#))
+    XCTAssertTrue(settings.contains(#"Text("SSD streaming")"#))
+    XCTAssertTrue(settings.contains("ssdStreamingCacheGB"))
+    XCTAssertTrue(settings.contains("routedExpertGiB"))
+    // Caption shows the freed amount for the selected quant.
+    XCTAssertTrue(settings.contains("frees ~"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" --filter ChatThinkMaxToggleTests`
+Expected: FAIL — strings not found.
+
+- [ ] **Step 3: Implement** — in `SettingsView.swift`:
+
+  Add computed helpers near `sessionsBinding`:
+
+```swift
+private var streamingCacheBinding: Binding<Double> {
+    Binding(get: { Double(app.ssdStreamingCacheGB) }, set: { app.ssdStreamingCacheGB = Int($0.rounded()) })
+}
+private var streamingCacheMaxGiB: Int {
+    max(17, Int(Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant).routedExpertGiB) - 1)
+}
+private var streamingCaption: String {
+    let q = Quant.for(app.selectedVariant, flashQuant: app.selectedFlashQuant)
+    let gb = app.ssdStreamingCacheGB
+    let freed = Int(q.routedExpertGiB - Double(gb))  // truncates: 82.69 − 67 → ~15 GiB
+    return
+        "Expert cache \(gb) GiB — frees ~\(freed) GiB of RAM from model weights. "
+        + "Decode can be slower when the SSD must refill the cache."
+}
+```
+
+  Insert a new section between the `Server` section and the `Apply & Restart Server` section:
+
+```swift
+Section {
+    Toggle("Stream expert weights from SSD", isOn: $app.ssdStreaming)
+    if app.ssdStreaming {
+        LabeledContent {
+            HStack(spacing: 10) {
+                Slider(value: streamingCacheBinding, in: 16...Double(streamingCacheMaxGiB), step: 1)
+                Text("\(app.ssdStreamingCacheGB)")
+                    .monospacedDigit().foregroundStyle(.secondary)
+                    .frame(width: 30, alignment: .trailing)
+            }
+            .frame(width: 230)
+        } label: {
+            Text("Expert cache")
+        }
+        Text(streamingCaption)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+} header: {
+    Text("SSD streaming")
+} footer: {
+    Text(
+        "Keeps only part of the routed expert weights in RAM and streams the rest "
+            + "from disk on demand, freeing memory for other apps. "
+            + "Applies on next server start or restart.")
+}
+```
+
+  (Note: the caption truncates the freed amount — `~15 GiB` for the 67 GB default — matching the default-budget formula, a deliberate deviation from the spec's rounded sketch.)
+
+- [ ] **Step 4: Verify** — full test suite green; `swift format lint --recursive Sources Tests` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/DS4Control/Views/SettingsView.swift Tests/DS4ControlTests/ChatThinkMaxToggleTests.swift
+git commit -m "feat: SSD streaming settings UI (toggle + expert-cache budget slider)"
+```
+
+### Task 6: Full build, tests, .app, and real-model verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (add an entry in the existing format)
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Full test suite**
+
+Run (from repo root, with `SWIFTUI_PLUGIN` exported):
+`swift test -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN"`
+Expected: all tests pass.
+
+- [ ] **Step 2: Release build**
+
+Run: `swift build -c release -Xswiftc -Xfrontend -Xswiftc -load-plugin-library -Xswiftc -Xfrontend -Xswiftc "$SWIFTUI_PLUGIN" -Xswiftc -warnings-as-errors`
+Expected: builds clean (CI parity).
+
+- [ ] **Step 3: Build the .app**
+
+Run (same plugin flag; `build.sh`'s own `swift build` line must be patched in a gitignored copy as was done for the initial bundle, or use the temporary wrapper at `.build/build-app.sh` from earlier — re-create it if missing by copying `build.sh` and adding the `-Xswiftc -Xfrontend -Xswiftc -load-plugin-library ...` flags to its `swift build -c release` line):
+`DS4_SRC="$PWD/external/ds4" bash .build/build-app.sh`
+Expected: `DS4 Control.app` builds, signed ad-hoc, `ds4-server` bundled.
+
+- [ ] **Step 4: Real-model launch (manual, heavy — optional but recommended)**
+
+Stop any running ds4-server first (`pkill -f ds4-server`). Launch with the exact args the app will pass for the default settings (q2-q4, 1M ctx, streaming 67 GB):
+
+```bash
+"$PWD/external/ds4/ds4-server" \
+  -m "/Users/pauleveritt/Library/Application Support/DS4 Control/gguf/DeepSeek-V4-Flash-Layers37-42Q4KExperts-OtherExpertLayersIQ2XXSGateUp-Q2KDown-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-fixed-0731.gguf" \
+  --ctx 1000000 --host 127.0.0.1 --port 8000 --metal \
+  --ssd-streaming --ssd-streaming-cache-experts 67GB \
+  --kv-disk-dir "$HOME/Library/Application Support/DS4 Control/kv" --kv-disk-space-mb 16384
+```
+
+Watch stderr for the startup cache report (grep `streaming expert cache`): it prints the actual expert budget and target GiB — the authoritative freed-amount signal. Then `ps -o rss= -p <pid>` and compare with a same-args-without-streaming launch if you want the empirical delta. Kill the server when done. (Loading the 91 GiB model takes minutes; do the comparison only if you have time for two loads.)
+
+- [ ] **Step 5: CHANGELOG**
+
+Add an entry under the top (unreleased) section, following the existing bullet style:
+`- SSD streaming (default on): keeps ~15 GiB less of the model resident by caching only part of the routed experts; budget slider in Settings.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog — SSD streaming"
+```
+
+---
+
+## Stage 2 (captured, NOT scheduled): Laguna S 2.1 support
+
+The user explicitly wants the no-Laguna build first; everything below is a scoped capture of the discussion for a future plan. **Not tasks to execute now.**
+
+**Goal (future):** let the app download and serve either DS4F (Pro/Flash) or Laguna S 2.1, with switching via the existing restart flow.
+
+### Requirements capture
+
+1. **Fork/submodule first (critical path).** The pinned submodule commit (`ebacae9`, `ds4-control-patches-v2`) predates Laguna. `laguna-s2.1` is a separate fork branch declaring a third family (`DS4_MODEL_FAMILY_LAGUNA`, 48 layers) in the same runtime-dispatched `ds4.c` (`DS4_MODEL_FAMILY`/`DS4_MODEL_VARIANT` are read from the GGUF shape at runtime — one server binary serves both, no separate build). The THINK_MAX patch must be rebased/merged onto a Laguna-capable commit, then the pin bumps and CI/release re-verified. `build.sh` needs no change (it bundles whatever the submodule has).
+2. **Downloads (DFlash explicitly SKIPPED per user).** DS4F repo: `antirez/deepseek-v4-gguf`. Laguna: `laguna-q4` → `poolside/Laguna-S-2.1-GGUF` / `laguna-s-2.1-Q4_K_M.gguf` (63.56 GiB, needs the fork's pinned `HF_REVISION` — the app's `HFDownloader` already supports `revision:`); `laguna-q2-q3` → `antirez/Laguna-S-2.1-GGUF` / `laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf` (44.95 GiB, 64 GB class). Skip `laguna-dflash` (`--dflash` speculative decoding) entirely. `SupervisorService.ggufRepo` becomes per-model repo+revision; progress totals need correct per-model `weightsGiB`.
+3. **Model table.** `Variant`/`FlashQuant` generalize into a model-family × quant structure: per-family `modelId`, layers (Laguna 48), `kvBytesPerToken`, `ctxCeiling` (Laguna ≠ 1M; likely far smaller — verify model card), quants, GGUF names, repo+revision, `routedExpertGiB` (below).
+4. **KV/ctx math must be re-measured.** `kvBytesPerToken = layers × 391` was measured for DS4F Flash only (via `scripts/flash-mem-harness.sh`); Laguna's attention (SWA layers) differs and needs its own harness run before `defaultCtx`/RAM budgets can be trusted.
+5. **Reasoning/thinking semantics.** The chat's `reasoning_content` section, Think-Max tiers (393,216 floor, `THINK_MAX` env), and the agent launcher's Max-Think prompt are DS4-specific. Laguna advertises native interleaved reasoning — verify SSE shape and prompts against a real server before reusing them.
+6. **Feasibility tier for true 64 GB class.** The app currently blocks <96 GiB. Laguna q2-q3 (44.95 GiB weights) targets 64 GB laptops: new tier + the existing wired-limit advisory math (with the 8 GiB OS reserve, weights + modest KV ≈ 55–57 GiB — tight but feasible).
+7. **SSD-streaming table.** Add measured `routedExpertGiB` for Laguna quants. q2-q3 is a *mixed* routed quant (Q2_K, last 27 layers Q3_K) — the same "boosted layers can't use the single-size-class expert cache" caveat as DS4F q2-q4; the Settings freed-RAM caption follows.
+8. **Chat model identity.** `ChatViewModel(model: app.selectedVariant.modelId, ...)` captures the id at launch; multi-model switching needs it bound to the running server (the `/v1/models` `loadedModelName` path already does this for adopted servers).
+9. **Shared KV cache — NOT a blocker.** On-disk KV entries are namespaced by `model_id` + `quant_bits` (`ds4_kvstore.c` rejects mismatches), so DS4F/Laguna never replay each other's prefixes in the shared `App Support/DS4 Control/kv` dir; the only shared effect is the 16 GiB `--kv-disk-space-mb` budget (mutual eviction, harmless). Optional clean split: per-family `kv/<family>` subdirs. No custom `$HOME` needed for the server.
+10. **Cleanup/migration generalization.** `cleanupUnusedFlashQuants` and the pre-0731 legacy-gguf banner are DS4F-shaped; new family files must be excluded and the loops generalized.
+11. **Tests.** Feasibility/ctx math for the new tier, downloader tests for the second repo+revision, a Laguna KV harness, and the existing `VariantTests`/`AppStateTests` extended for the family table.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every design-spec decision maps to a task — per-quant table (T1), AppState defaults/persistence (T2), arg construction incl. the 0-budget edge (T3), all four call sites (T4), Settings UI with freed-RAM caption (T5), full verification + changelog (T6). Out-of-scope items (feasibility relaxation, cold/preload knobs, per-quant persisted budgets) are deliberately absent. Laguna points are fully captured in Stage 2 with DFlash excluded.
+- **Placeholder scan:** no TBD/TODO; every step has concrete code or commands. The one "re-create if missing" reference (`.build/build-app.sh`) names the exact recipe to rebuild it.
+- **Type consistency:** `routedExpertGiB` (T1) is consumed by T2 (via `Quant.for`) and T5; `ssdStreaming`/`ssdStreamingCacheGB` names are identical across T2–T5; Task 3 signatures use exactly `ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0`; test values (67GB, 67, 409/130/58/67) match the truncating formula throughout.

--- a/docs/superpowers/specs/2026-08-12-laguna-support-design.md
+++ b/docs/superpowers/specs/2026-08-12-laguna-support-design.md
@@ -1,0 +1,121 @@
+# Laguna S 2.1 Support — Design
+
+**Date:** 2026-08-12
+**Status:** Approved in conversation (2026-08-12); written for review
+**Branch/worktree:** `feat/laguna` at `.worktrees/feat-laguna` (forked from `feat/ssd-streaming`)
+
+## Goal
+
+Let DS4 Control install and serve **Laguna S 2.1 (q2-q3)** alongside DS4F (V4 Pro / V4 Flash), with switching between them via the existing restart flow. Primary target: **64 GB-class laptops**, where q2-q3 is the only feasible model. The app continues to supervise one `ds4-server` at a time.
+
+## Decisions (all settled in conversation)
+
+1. **One new model: `laguna-q2-q3`** (`laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf`, 44.95 GiB). No `laguna-q4`, no other Laguna quants.
+2. **No DFlash.** The draft-model download, `--dflash` plumbing, and greedy-temperature interplay are deferred — the user hasn't validated DFlash's value, and DFlash is mutually exclusive with SSD streaming upstream.
+3. **Combined fork branch.** `laguna-s2.1` was merged into `ds4-control-patches-v2` as **`ds4-control-patches-v3`**; 15 conflict files resolved; the merged `ds4-server` **builds clean and was boot-validated against the real q2-q3 GGUF** (served `/v1/models` as `laguna-s-2.1`, generated a completion; KV report 2.36 GiB @ 50k matched the research formula). The app's submodule pin moves to this branch. The THINK_MAX 0731-prefix fix is retained.
+4. **SSD streaming is DS4F-only.** ds4 hard-refuses `--ssd-streaming` for Laguna S 2.1 ("not implemented … yet", `ds4_engine_open_internal`, no env override) — the server won't start. The app must never pass the flag for Laguna; the Settings toggle shows N/A for Laguna. The Stage-1 default-ON setting must not break Laguna launches.
+5. **Built-in chat works for Laguna, thinking-mode picker hidden.** No Instant/Standard/Max Think toggle for Laguna (DS4F semantics, 393,216 floor); the chat sends no thinking override and renders whatever ds4 emits. A live SSE smoke test verifies the reasoning shape during implementation.
+6. **Unified model picker.** A `Model` (family × quant) replaces the variant/quant pair as the app's identity. The popup lists feasible models (name + resident size); Settings' model section generalizes; switching = restart (full reload).
+7. **Feasibility floor 64 GiB; default ctx 50,000; `--prefill-chunk 4096` for Laguna.** q2-q3 all-resident needs ~51 GiB planned with the bounded chunk (weights 44.95 + KV 2.36 @ 50k + scratch ~1.5 + buffers ~2); the default prefill 16384 costs ~5.9 GiB of scratch and pushes 64 GB machines into the pressure zone. Wired-limit advisory applies to the 64–95 GiB band.
+8. **Per-model download metadata.** `downloadRepo = "antirez/Laguna-S-2.1-GGUF"`, `downloadRevision = "main"`, `weightsGiB = 44.95` (measured from the GGUF on disk). `HFDownloader` (already supports `revision:`) is constructed per `download()` from model metadata; the injectable fetch closure signature is unchanged. Cleanup is family-scoped; the pre-0731 legacy migration stays DS4F-only.
+
+## Model facts (measured from the GGUF on disk, 2026-08-12)
+
+| Field | Laguna S 2.1 q2-q3 |
+|---|---|
+| File | `laguna-s-2.1-RoutedQ2_K-Last27Q3_K.gguf` (44.95 GiB) |
+| Blocks / sparse layers | 48 blocks, 1 leading dense → 47 sparse |
+| Global layers (`il%4==0`) / SWA (window 512) | 12 / 36 |
+| Routed expert tensors | **40.87 GiB** (gate 13.62 + up 13.62 + down 13.62) |
+| Non-routed | ~4.1 GiB (attn 2.77 + embeddings/shared FFN ~1.3) |
+| Per-layer expert classes | 0.738 GiB (Q2_K) vs 0.967 GiB (Q3_K) — **mixed** |
+| KV @ 50k ctx | 2.36 GiB (formula + boot-verified) |
+| Graph scratch @ 50k, prefill 16384 / 4096 | ~5.9 GiB / ~1.5 GiB |
+| Model id | `laguna-s-2.1` |
+| Context ceiling | **262,144** (`laguna.context_length` GGUF key) |
+
+## Changes
+
+### 1. `Model` abstraction (`Model/Variant.swift` + new `Model/Model.swift`)
+
+A `Model` fully determines identity and behavior. Represent as an enum of the runnable models:
+
+- `v4Pro`, `v4Flash(q2/q2q4/q4)`, `lagunaS21` (q2-q3)
+
+Per-model members (mirroring/absorbing the existing `Variant`/`Quant`/`FlashQuant` surface):
+
+```swift
+var displayName: String            // "V4 Pro", "V4 Flash", "Laguna S 2.1"
+var modelId: String                // "deepseek-v4-pro", "deepseek-v4-flash", "laguna-s-2.1"
+var layers: Int
+var ctxCeiling: Int                // Laguna 262,144 (GGUF metadata); DS4F 1,000,000
+var weightsGiB: Double             // 432 / 153 / 81 / 91 / 44.95
+var downloadRepo: String           // "antirez/deepseek-v4-gguf" | "antirez/Laguna-S-2.1-GGUF"
+var downloadRevision: String       // "main" for all current models
+var ggufFilename: String
+var supportsSSDStreaming: Bool     // DS4F true; Laguna false (hard ds4 gate)
+var supportsThinkingModes: Bool    // DS4F true; Laguna false (v1)
+var defaultCtx(ramGiB:) -> Int     // DS4F existing tiers; Laguna 50,000
+var defaultPrefillChunk: Int?      // Laguna 4096; DS4F nil (ds4 default)
+var feasibility(ramGiB:) -> Feasibility
+var routedExpertGiB: Double?       // DS4F quants (SSD-streaming table); nil for Laguna
+```
+
+Keep `Variant`/`Quant`/`FlashQuant` where the existing download/feasibility code keys off them, or fold them into `Model` — the plan picks the migration that touches the fewest call sites while delivering the unified picker.
+
+### 2. `AppState`
+
+- Replace the `selectedVariant`/`selectedFlashQuant` pair with `selectedModel: Model` (persisted by raw value), or keep the pair and add `selectedFamily` — the plan chooses the shape that makes the unified picker and family gates least invasive, defaulting to a single `selectedModel`.
+- `ssdStreaming`/`ssdStreamingCacheGB` (Stage 1) stay global; the launch layer gates them per model.
+
+### 3. `SupervisorService`
+
+`start()`/`restart()` args become model-family-aware:
+
+- gguf path from `model.ggufFilename` (no change in mechanics)
+- `--ssd-streaming`/`--ssd-streaming-cache-experts` **only when `model.supportsSSDStreaming && app.ssdStreaming`**
+- `--prefill-chunk 4096` **only for Laguna**
+- `download(...)` builds `HFDownloader(repo: model.downloadRepo, revision: model.downloadRevision)` per call; `SupervisorService.ggufRepo` static removed
+- cleanup generalized: "keep the selected model, delete other quants of the same family; never touch the other family"
+
+### 4. `Feasibility` + default ctx
+
+- Laguna q2-q3 tier: `< 64 GiB` blocked; `64–95 GiB` `.warnWiredLimit` (default GPU wired limit ~0.67×RAM ≈ 43 GiB < 44.95 GiB weights — must be raised); `≥ 96 GiB` `.standard`.
+- `defaultCtx`: Laguna 50,000 across tiers (ctx override remains; KV is SWA-capped so context is cheap; scratch is bounded by the prefill chunk).
+
+### 5. Chat + agents
+
+- `ChatViewModel` model id bound to the running server (already done for adopted servers) so family switches don't leave a stale DS4F id.
+- Thinking-mode picker hidden when `!model.supportsThinkingModes`; chat sends no thinking override for Laguna.
+- `AgentLauncher` family-aware: Laguna gets its model id + context window and no DS4F Max-Think prompt.
+- Verify the live SSE shape for Laguna (reasoning interleaving) during implementation.
+
+### 6. Submodule pin
+
+- Point `external/ds4` at `ds4-control-patches-v3` (currently `d0b0caa` in the worktree). **The branch must be pushed to the fork** (`notatestuser/ds4`) before CI (`submodules: recursive`) and release builds can resolve it.
+- The app-side pin change is one line (`git -C external/ds4 ...` + commit the `.gitmodules`/submodule pointer), staged after the fork branch is pushed.
+
+## Out of scope
+
+- `laguna-q4`, `Laguna XS`, other Laguna builds
+- DFlash download/`--dflash`/greedy-temperature plumbing (deferred; captured: ds4 supports DFlash for Laguna on Metal, but it's mutually exclusive with SSD streaming)
+- SSD streaming for Laguna (ds4 hard gate — no app workaround)
+- Relaxing the DS4F gates (Flash ≥96, Pro ≥512) to enable streaming-based fits — not requested
+- Per-model persisted SSD-streaming budgets (single global budget, as in Stage 1)
+
+## Tests
+
+- `Model` table: displayName/modelId/weightsGiB/downloadRepo/ggufFilename/supports* per model; Laguna weightsGiB = 44.95
+- Feasibility: Laguna tiers (64 floor, wired-limit band, standard band); `defaultCtx` 50,000
+- Supervisor args: Laguna launch passes `--prefill-chunk 4096`, never `--ssd-streaming` even when `ssdStreaming` is on; DS4F behavior unchanged; download uses the Laguna repo+filename
+- Downloader: second repo (`antirez/Laguna-S-2.1-GGUF`) fetch path
+- AppState: `selectedModel` persistence; `ssdStreaming` still defaults on but is inert for Laguna
+- Source tests: thinking-picker gating and SSD-section N/A state for Laguna
+- All Stage-1 tests keep passing
+
+## Manual verification
+
+- Live boot of q2-q3 via the app path (already proven with the merged binary): KV report, `/v1/models` model id, one generation
+- SSE smoke test for the chat reasoning shape
+- 64 GB-class feasibility math (planned ~51 GiB with `--prefill-chunk 4096`); wired-limit advisory shows for 64–95 GiB
+- `--ssd-streaming` refusal confirmed for Laguna (server refuses; app never sends it)

--- a/docs/superpowers/specs/2026-08-12-ssd-streaming-design.md
+++ b/docs/superpowers/specs/2026-08-12-ssd-streaming-design.md
@@ -1,0 +1,158 @@
+# SSD Streaming Support — Design
+
+**Date:** 2026-08-12
+**Status:** Approved (2026-08-12)
+
+## Goal
+
+Let ds4-control run `ds4-server` with SSD streaming enabled by default, freeing
+~15 GiB of resident model weights (moved to SSD). Expose it as a Settings
+toggle with an expert-cache budget slider, defaulted to the value that frees
+~15 GiB on the selected model.
+
+## Background
+
+`ds4-server` (antirez/ds4, vendored at `external/ds4`) supports SSD-backed
+model streaming (`--ssd-streaming`): non-routed weights stay resident while
+routed MoE experts live in an in-memory cache and load from the GGUF on cache
+misses. The routed-expert cache budget is `--ssd-streaming-cache-experts
+NGB` (memory budget) or `N` (exact expert count). A plain `--ssd-streaming`
+uses an automatic budget of 80% of the backend's recommended working set
+minus non-routed weights — on this machine (M5 Max, 128 GiB, Metal
+recommended working set 107.5 GiB) that frees only ~5 GiB, so an explicit
+budget is required to reach the ~15 GiB target.
+
+### Measured model facts (q2-q4 0731, the default on ≥128 GiB machines)
+
+Parsed from the downloaded GGUF metadata (`DeepSeek-V4-Flash-...-fixed-0731.gguf`):
+
+| Tensor family | Size |
+|---|---|
+| `ffn_down_exps` (routed) | 31.0 GiB |
+| `ffn_gate_exps` (routed) | 25.8 GiB |
+| `ffn_up_exps` (routed) | 25.8 GiB |
+| **Total routed experts** | **82.7 GiB** |
+| Non-routed (attn, embeddings, shared FFN, norms) | ~8.3 GiB |
+| Total | ~91 GiB (matches file size) |
+
+Freeing ~15 GiB ⇒ expert-cache budget ≈ **67 GB**
+(`--ssd-streaming-cache-experts 67GB`), freeing 82.7 − 67 ≈ 15.7 GiB. ds4 may
+cap an explicit budget down (7/8 of recommended working set minus context
+memory), which only increases the amount freed; its startup log reports the
+actual cache size ("streaming expert cache budget=… target=… GiB").
+
+## Decisions
+
+- **Default ON.** Fresh installs run with SSD streaming enabled and the
+  ~15 GiB-free budget. Users can toggle off or dial the budget back toward
+  "keep more in RAM" if cache-miss decode feels slow.
+- **Per-quant default budget** so "frees ~15 GiB" holds for any Flash quant
+  (q2: 58 GB, q2-q4: 67 GB, q4: 130 GB) and Pro (409 GB). Derived from a
+  small hardcoded `routedExpertGiB` table on `Quant` (q2-q4 measured from the
+  GGUF; others estimated as weights minus ~8 GiB non-routed).
+- **One persisted budget value** (not per-quant keyed). If the user changes
+  quant, the saved budget is kept — their explicit choice. The Settings
+  caption shows the effective freed amount for the currently selected quant.
+- **UI lives in Settings** (matches existing Toggle+Slider row pattern),
+  applied by the existing Apply/Restart flow. No popup changes.
+- **Out of scope:** relaxing the RAM feasibility gate to run Pro below
+  512 GiB (ds4 supports streaming Pro on 128 GiB, but not requested);
+  `--ssd-streaming-cold` / `--ssd-streaming-preload-experts` (measurement-only);
+  per-quant persisted budgets; runtime GGUF parsing for exact expert bytes
+  (ds4's log + safety cap absorb estimation error).
+
+## Changes
+
+### 1. `Model/Variant.swift`
+
+Add to `Quant`:
+
+```swift
+/// Routed-expert tensor bytes (GiB) — the weights SSD streaming can push to
+/// disk. q2-q4 measured from the 0731 GGUF metadata; others estimated as
+/// total weights minus ~8 GiB non-routed (attn/embeddings/shared FFN).
+var routedExpertGiB: Double {
+    switch self {
+    case .proImatrix: return 424
+    case .q4Imatrix: return 145
+    case .q2Imatrix: return 73
+    case .q2q4Imatrix: return 82.69
+    }
+}
+
+/// Default SSD-streaming expert-cache budget (GiB) for this quant: leaves
+/// ~15 GiB of resident routed experts to stream from SSD. Floor 16 GiB so a
+/// degenerate tiny cache can never be configured accidentally.
+var defaultStreamingCacheGB: Int { max(16, Int(routedExpertGiB - 15)) }  // truncates: 82.69−15 → 67
+```
+
+### 2. `AppState.swift`
+
+Follow the existing `@Published` + `didSet` persistence pattern:
+
+```swift
+/// SSD streaming: cache only `ssdStreamingCacheGB` of routed experts in RAM;
+/// the rest stream from the GGUF on demand. Default ON with the ~15 GiB-free
+/// budget for the default quant.
+@Published var ssdStreaming: Bool { didSet { d.set(ssdStreaming, forKey: "ssdStreaming") } }
+@Published var ssdStreamingCacheGB: Int {
+    didSet { d.set(ssdStreamingCacheGB, forKey: "ssdStreamingCacheGB") }
+}
+```
+
+`init` read-back: `ssdStreaming = d.object(forKey: "ssdStreaming") as? Bool ?? true`
+(default on); `ssdStreamingCacheGB` defaults to
+`Quant.for(selectedVariant, flashQuant: selectedFlashQuant).defaultStreamingCacheGB`
+when unset (compute after the quant/variant read-backs), else the stored value.
+
+### 3. `Services/SupervisorService.swift`
+
+Extend `start(...)` and `restart(...)` with defaulted params
+`ssdStreaming: Bool = false, ssdStreamingCacheGB: Int = 0`. In the args
+assembly (after the `--metal` block):
+
+```swift
+if ssdStreaming {
+    args += ["--ssd-streaming"]
+    if ssdStreamingCacheGB > 0 {
+        args += ["--ssd-streaming-cache-experts", "\(ssdStreamingCacheGB)GB"]
+    }
+}
+```
+
+### 4. Call sites (thread `app.ssdStreaming` / `app.ssdStreamingCacheGB`)
+
+- `Views/ModelRowView.swift` — two `supervisor.start(...)` calls
+- `Views/ThinkingModeControls.swift` — one `supervisor.restart(...)` call
+- `Views/SettingsView.swift` — `restart()` helper
+
+### 5. `Views/SettingsView.swift` — new section
+
+New section following the existing Toggle + Slider row pattern:
+
+- Toggle: "Stream expert weights from SSD"
+- When on: slider, range `16...(max(17, Int(quant.routedExpertGiB) - 1))`, step 1,
+  plus a caption computing freed RAM for the currently selected quant:
+  `"Expert cache \(gb) GiB — frees ~\(Int((quant.routedExpertGiB - Double(gb)).rounded())) GiB of RAM. Decode can be slower when the SSD must refill the cache."`
+- Footer note explaining the tradeoff; changes apply via the existing
+  Apply/Restart flow.
+
+## Tests
+
+- `SupervisorStateMachineTests` (or the existing fake-runner integration
+  tests): `start` with `ssdStreaming: true, ssdStreamingCacheGB: 67` passes
+  `--ssd-streaming` and `--ssd-streaming-cache-experts 67GB`; with `false`
+  passes neither.
+- `VariantTests`: `defaultStreamingCacheGB` per quant (q2-q4 → 67, q2 → 58,
+  q4 → 130, pro → 409); floor of 16.
+- `AppState` default assertions: fresh install → `ssdStreaming == true`,
+  `ssdStreamingCacheGB == 67` (default quant q2-q4 on ≥128 GiB).
+- All existing tests keep passing (new params defaulted).
+
+## Manual verification
+
+Launch `ds4-server` with the real q2-q4 model and the flags
+(`-m <gguf> --ctx 1000000 --metal --ssd-streaming
+--ssd-streaming-cache-experts 67GB`), read the startup cache report line, and
+compare resident memory vs. a non-streaming launch: expect ~15 GiB less
+resident RAM. The app's stderr tail (`recentLog`) surfaces the same report.


### PR DESCRIPTION
## What

Install and serve **Laguna S 2.1 (q2-q3, 44.95 GiB)** alongside DS4F — the 64 GB-laptop option. Adds a unified model picker (V4 Pro / V4 Flash variants / Laguna S 2.1), download, serve, basic chat, and agent support.

## Why

DeepSeek V4 Flash needs ≥96 GiB; on 64 GB machines the *only* feasible model is Laguna q2-q3.

## How

- **`Model` enum** as the single model identity (display name, modelId, layers, ctx ceiling 262,144, weights, download repo/filename, capability flags).
- **Feasibility tiers**: Laguna ≥96 GiB standard · 64–95 warn wired-limit · <64 blocked; default ctx **50,000** (SWA-capped KV — measured 2.36 GiB @50k).
- **`AppState.selectedModel`** replacing the variant/quant pair, with legacy-key migration.
- **Family-aware launch**: SSD streaming **never** passed for Laguna (ds4 hard-refuses it), `--power` gated (ds4 "standard graph path only"), `--prefill-chunk` omitted.
- **Per-model downloader** (`antirez/Laguna-S-2.1-GGUF`) + family-scoped cleanup.
- **Chat/agents**: thinking-mode picker hidden for Laguna (native interleaved reasoning), `laguna-s-2.1` in the pi models.json.

## Dependencies

- **Stacks on #20 (SSD streaming)** — merge that first; this diff then reduces to Laguna-only.
- **Fork branch**: the submodule pin (`d0b0caa`) is the merge of `laguna-s2.1` into `ds4-control-patches-v2` (15 conflict files resolved: enum unions, `edit_upto`×tool-syntax composition, Metal kernel-signature supersets, a restored `ds4_gpu_wrap_f32_decode_model_range`). It's pushed at **`pauleveritt/ds4:ds4-control-patches-v3`** for reference — please fetch and push it to your fork (or merge `laguna-s2.1` into `ds4-control-patches-v2` yourself) so the pin resolves.

## Verification

- 227 tests
- Live boot: `/v1/models` → `laguna-s-2.1` @50k, generation OK, SSE shape clean (content deltas + usage event).

Docs: `docs/superpowers/specs/2026-08-12-laguna-support-design.md` (+ TDD plan).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and downloading Laguna S 2.1.
  * Added SSD-backed expert streaming with adjustable cache sizing, enabled by default where supported.
  * Added model-specific RAM feasibility checks and context defaults.
  * Updated model selection, downloads, cleanup, startup, and restart flows for multiple model families.
  * Thinking-mode controls now appear only for compatible models.
* **Documentation**
  * Documented Laguna S 2.1 requirements and SSD streaming configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->